### PR TITLE
Add usbsdmux group

### DIFF
--- a/contrib/systemd/sysusers.d/usbsdmux.conf
+++ b/contrib/systemd/sysusers.d/usbsdmux.conf
@@ -1,0 +1,2 @@
+# Type	Name		ID	GECOS		Home directory Shell
+u	usbsdmux	-	"USB-SD-Mux"

--- a/contrib/systemd/usbsdmux.service
+++ b/contrib/systemd/usbsdmux.service
@@ -6,6 +6,8 @@ Requires=usbsdmux.socket
 [Service]
 Type=simple
 ExecStart=/path/to/usb-sd-mux/.venv/bin/usbsdmux-service
+User=usbsdmux
+Group=usbsdmux
 
 [Install]
 WantedBy=multi-user.target

--- a/contrib/udev/99-usbsdmux.rules
+++ b/contrib/udev/99-usbsdmux.rules
@@ -1,2 +1,4 @@
-ACTION=="add", SUBSYSTEM=="scsi_generic", KERNEL=="sg[0-9]", ATTRS{manufacturer}=="Pengutronix", ATTRS{product}=="usb-sd-mux*", SYMLINK="usb-sd-mux/id-$attr{serial}"
-ACTION=="add", SUBSYSTEM=="scsi_generic", KERNEL=="sg[0-9]", ATTRS{manufacturer}=="Linux Automation GmbH", ATTRS{product}=="usb-sd-mux*", SYMLINK="usb-sd-mux/id-$attr{serial}"
+ACTION=="add", SUBSYSTEM=="scsi_generic", KERNEL=="sg[0-9]", ATTRS{manufacturer}=="Pengutronix", ATTRS{product}=="usb-sd-mux*", SYMLINK="usb-sd-mux/id-$attr{serial}", GROUP="usbsdmux"
+ACTION=="add", SUBSYSTEM=="scsi_generic", KERNEL=="sg[0-9]", ATTRS{manufacturer}=="Linux Automation GmbH", ATTRS{product}=="usb-sd-mux*", SYMLINK="usb-sd-mux/id-$attr{serial}", GROUP="usbsdmux"
+
+SUBSYSTEM=="block", ENV{ID_VENDOR}=="LinuxAut", ENV{ID_MODEL}=="sdmux_HS-SD_MMC", GROUP="usbsdmux"

--- a/usbsdmux/usb2642i2c.py
+++ b/usbsdmux/usb2642i2c.py
@@ -316,7 +316,7 @@ class Usb2642I2C(object):
 #    print("SGIO:")
 #    print(self.to_pretty_hex(sgio))
 
-    with open(self.sg, 'r') as fh:
+    with open(self.sg, 'w+b', buffering=0) as fh:
       rc =  fcntl.ioctl(fh, self._SG_IO, sgio)
       if rc != 0:
         raise IoctlFailed("SG_IO ioctl() failed with non-zero exit-code {}"\


### PR DESCRIPTION
Limit the privileges of the service and give normal users write access to the block device (for e.g. writing an image) via the following measures:
- Create a usbsdmux user and group via sysusers.d file.
- Assign block and sg devices to the usbsdmux group via udev.
- Run the service as user and group usbsdmux.

Only if write access to the block device is required should the user become a member of the usbsdmux group; it is not necessary for socket communication with the service.