### PR TITLE
Allow querying of currently selected mode

### DIFF
--- a/usbsdmux/__main__.py
+++ b/usbsdmux/__main__.py
@@ -34,6 +34,8 @@ def direct_mode(sg, mode):
         ctl.mode_DUT()
     elif mode.lower() == "host":
         ctl.mode_host()
+    elif mode.lower() == "get":
+        print(ctl.get_mode())
 
 def client_mode(sg, mode, socket_path):
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_SEQPACKET)
@@ -65,11 +67,12 @@ def main():
     parser.add_argument(
         "mode",
         help="Action:\n"
+             "get - return selected mode\n"
              "dut - set to dut mode\n"
              "client - set to dut mode (alias for dut)\n"
              "host - set to host mode\n"
              "off - set to off mode",
-        choices=["dut", "client", "host", "off"],
+        choices=["get", "dut", "client", "host", "off"],
         type=str.lower)
     parser.add_argument(
         "-d",

--- a/usbsdmux/__main__.py
+++ b/usbsdmux/__main__.py
@@ -57,13 +57,19 @@ def client_mode(sg, mode, socket_path):
         exit(1)
 
 def main():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter
+    )
 
     parser.add_argument("sg", metavar="SG", help="/dev/sg* to use")
     parser.add_argument(
         "mode",
-        help="mode to switch to",
-        choices=["dut", "host", "off", "client"],
+        help="Action:\n"
+             "dut - set to dut mode\n"
+             "client - set to dut mode (alias for dut)\n"
+             "host - set to host mode\n"
+             "off - set to off mode",
+        choices=["dut", "client", "host", "off"],
         type=str.lower)
     parser.add_argument(
         "-d",

--- a/usbsdmux/pca9536.py
+++ b/usbsdmux/pca9536.py
@@ -66,6 +66,12 @@ class Pca9536(object):
 
     self._usb.write_to(self._I2cAddr, [register, value])
 
+  def read_register(self, address, length=1):
+    """
+    Returns a register of the Pca9536.
+    """
+    return self._usb.write_read_to(self._I2cAddr, [address], length)
+
   def set_pin_to_output(self, pins):
     """
     Sets the corresponding pins as outputs.

--- a/usbsdmux/service.py
+++ b/usbsdmux/service.py
@@ -49,6 +49,8 @@ The service always answers with a payload like the following:
 
 For example:
 {"error": False, "text": "Success"}
+or as a result of mode=get:
+{"error": False, "text": "dut"}
 """
 # Default filedescriptor used by systemd to pass us a socket
 systemd_socket_fd = 3
@@ -96,6 +98,9 @@ def process_request(raw_string):
 
         elif payload["mode"].lower() == "host":
             ctl.mode_host()
+
+        elif payload["mode"].lower() == "get":
+            return create_answer(err_text=ctl.get_mode())
 
         else:
             return create_answer(had_error=True, err_text="Unknown mode")

--- a/usbsdmux/usbsdmux.py
+++ b/usbsdmux/usbsdmux.py
@@ -57,6 +57,18 @@ class UsbSdMux(object):
         Pca9536.gpio_0 | Pca9536.gpio_1 |
         Pca9536.gpio_2 | Pca9536.gpio_3)
 
+  def get_mode(self):
+    """
+    Returns currently selected mode as string
+    """
+    val = self._pca.read_register(1)[0]
+    if val & self._select_DUT:
+       return "dut"
+    if val & self._PWR_disable:
+       return "off"
+
+    return "host"
+
   def mode_disconnect(self, wait=True):
     """
     Will disconnect the Micro-SD Card from both host and DUT.

--- a/usbsdmux/usbsdmux.py
+++ b/usbsdmux/usbsdmux.py
@@ -47,15 +47,22 @@ class UsbSdMux(object):
     sg -- /dev/sg* to use
     """
     self._pca = Pca9536(sg)
+    self.write_mode = False
+
+  def _init_write(self):
+    if self.write_mode:
+        return
 
     # setting the output-values to defaults before enabling outputs on the
     # GPIO-expander
-    self.mode_disconnect(wait=False)
+    self.mode_disconnect(wait=False, init_write=False)
 
     # now enabling outputs
     self._pca.set_pin_to_output(
         Pca9536.gpio_0 | Pca9536.gpio_1 |
         Pca9536.gpio_2 | Pca9536.gpio_3)
+
+    self.write_mode = True
 
   def get_mode(self):
     """
@@ -69,7 +76,7 @@ class UsbSdMux(object):
 
     return "host"
 
-  def mode_disconnect(self, wait=True):
+  def mode_disconnect(self, wait=True, init_write=True):
     """
     Will disconnect the Micro-SD Card from both host and DUT.
 
@@ -77,6 +84,8 @@ class UsbSdMux(object):
     wait -- Command will block for some time until the voltage-supply of
     the sd-card is known to be close to zero
     """
+    if init_write:
+        self._init_write()
 
     self._pca.output_values(self._DAT_disable | self._PWR_disable |
                             self._select_HOST | self._card_removed)
@@ -90,6 +99,7 @@ class UsbSdMux(object):
     This Command will issue a disconnect first to make sure the the SD-card
     has been properly disconnected from both sides and it's supply was off.
     """
+    self._init_write()
 
     self.mode_disconnect(wait)
 
@@ -109,6 +119,7 @@ class UsbSdMux(object):
     This Command will issue a disconnect first to make sure the the SD-card
     has been properly disconnected from both sides and it's supply was off.
     """
+    self._init_write()
 
     self.mode_disconnect(wait)
 


### PR DESCRIPTION
In case the status LEDs of the usbsdmux are not visible to the user, due to the position of the SD slot or due to remote control, the currently selected mode might be unknown.

Possible scenarios:
- the test host connected via USB might have been rebooted since the last mode set
- another user changed the mode

Currently it is only possible to look at the status LEDs or set the desired mode once again explicitly. This PR adds the possibility to query the selected mode.