### PR TITLE
usbsdmux: honor wait argument in mode_disconnect()

### DIFF
--- a/usbsdmux/usbsdmux.py
+++ b/usbsdmux/usbsdmux.py
@@ -69,7 +69,8 @@ class UsbSdMux(object):
     self._pca.output_values(self._DAT_disable | self._PWR_disable |
                             self._select_HOST | self._card_removed)
 
-    time.sleep(1)
+    if wait:
+        time.sleep(1)
 
   def mode_DUT(self, wait=True):
     """


### PR DESCRIPTION
Only sleep one second until the voltage-supply of the SD card is ~0 if `wait=True` is given.

Fixes: 3f9f04a ("High Level Application to control the usb-sd-mux from the command line")