### PR TITLE
Remove global exclude which leads to missing usbsdmux executable

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,6 @@ include LICENSE
 include fastentrypoints.py
 graft contrib
 
-global-exclude .*
 global-exclude *~
 global-exclude *.swp
 global-exclude *.pyc


### PR DESCRIPTION
This is a potential fix for #29 