### PR TITLE
Validate sg device path and descriptor

### DIFF
--- a/usbsdmux/__main__.py
+++ b/usbsdmux/__main__.py
@@ -25,8 +25,8 @@ import json
 import socket
 import os
 
-def direct_mode(sg, mode):
-    ctl = UsbSdMux(sg)
+def direct_mode(sg, mode, validate_usb=True):
+    ctl = UsbSdMux(sg, validate_usb)
 
     if mode.lower() == "off":
         ctl.mode_disconnect()
@@ -78,6 +78,12 @@ def main():
         action="store_true",
         default=False)
     parser.add_argument(
+        "-f",
+        "--force",
+        help=argparse.SUPPRESS,
+        action="store_true",
+        default=False)
+    parser.add_argument(
         "-s",
         "--socket",
         help="Overrides the default socket for client mode.",
@@ -92,10 +98,10 @@ def main():
     if args.client is True:
         client_mode(args.sg, args.mode, args.socket)
     elif args.direct is True:
-        direct_mode(args.sg, args.mode)
+        direct_mode(args.sg, args.mode, not args.force)
     else:
         if os.getresuid()[0] == 0:
-            direct_mode(args.sg, args.mode)
+            direct_mode(args.sg, args.mode, not args.force)
         else:
             client_mode(args.sg, args.mode, args.socket)
 

--- a/usbsdmux/pca9536.py
+++ b/usbsdmux/pca9536.py
@@ -44,16 +44,18 @@ class Pca9536(object):
   _direction_output = 0
   _direction_input = 1
 
-  def __init__(self, sg):
+  def __init__(self, sg, validate_usb=True):
     """
     Create a new Pca9536-controller.
 
     Arguments:
     sg -- /dev/sg* to use.
+    validate_usb -- Check if the USB descriptor fields of the sg device match known
+                    USB-SD-Muxes values.
     """
-    self.sg = sg
 
-    self._usb = Usb2642I2C(sg)
+    self._usb = Usb2642I2C(sg, validate_usb)
+    self.sg = sg
 
     # After POR all Pins are Inputs. This value will from now on mirror the
     # value of die _register_configuration

--- a/usbsdmux/service.py
+++ b/usbsdmux/service.py
@@ -158,7 +158,7 @@ def main():
             conn, addr = sock.accept()
             answer = process_request(
                 conn.recv(4096).decode(),
-                not self.force
+                not args.force
             )
             conn.send(answer.encode())
             conn.close()

--- a/usbsdmux/usb2642eeprom.py
+++ b/usbsdmux/usb2642eeprom.py
@@ -43,7 +43,7 @@ class USB2642Eeprom(object):
   Provides an interface to write the configuration EEPROM of a USB2642.
   """
 
-  def __init__(self, sg, i2c_addr=0x50):
+  def __init__(self, sg, i2c_addr=0x50, validate_usb=False):
     """"
     Create a new USB2642Eeprom Instance.
 
@@ -51,9 +51,12 @@ class USB2642Eeprom(object):
     sg -- /dev/sg* to use
     i2c_addr -- 7-Bit Address of the EEPROM to use. Defaults to 0x50 for the
                 configuration-EEPROM. You probably do NOT want to override this.
+    validate_usb -- Check if the USB descriptor fields of the sg device match known
+                    USB-SD-Muxes values. By default do'nt, as this tool is used
+                    to initially write these values.
     """
 
-    self.i2c = Usb2642I2C(sg)
+    self.i2c = Usb2642I2C(sg, validate_usb)
     self.addr = i2c_addr
 
   class _EepromStruct(ctypes.Structure):

--- a/usbsdmux/usbsdmux.py
+++ b/usbsdmux/usbsdmux.py
@@ -39,14 +39,16 @@ class UsbSdMux(object):
   _card_inserted = 0x00
   _card_removed = Pca9536.gpio_3
 
-  def __init__(self, sg):
+  def __init__(self, sg, validate_usb=True):
     """
     Create a new UsbSdMux.
 
     Arguments:
     sg -- /dev/sg* to use
+    validate_usb -- Check if the USB descriptor fields of the sg device match known
+                    USB-SD-Muxes values.
     """
-    self._pca = Pca9536(sg)
+    self._pca = Pca9536(sg, validate_usb)
 
     # setting the output-values to defaults before enabling outputs on the
     # GPIO-expander
@@ -106,4 +108,3 @@ class UsbSdMux(object):
     # now connect data and power
     self._pca.output_values(self._DAT_enable | self._PWR_enable |
                             self._select_HOST | self._card_inserted)
-


### PR DESCRIPTION
The usbsdmux command and usbsdmux-service do not validate
the supplied device path. This is not ideal, especially for
the service, as it allows normal users to send a sequence
of weird ioctl to any device they want.

This commit adds checks for the device path and USB descriptor
values while still allowing the user to override these checks.
This fixes #26.