### PR TITLE
Add a "list" subcommand to show available USB-SD-Muxes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,13 +44,16 @@ Install usbsdmux into the virtualenv:
 
    $ pip install usbsdmux
 
-Now you can run ``usbsdmux`` command by giving the appropriate /dev/sg* device,
-e.g.:
+Now you can run ``usbsdmux list`` to get a list of connected usb-sd-muxes:
 
 .. code-block:: bash
 
-   $ usbsdmux /dev/sg1 dut
-   $ usbsdmux /dev/sg1 host
+   $ usbsdmux list
+   Path       | Manufacturer          | Product           | Version | Serial
+   /dev/sg1   | Pengutronix           | usb-sd-mux_rev2.0 | 2.00    | 000000000064
+   /dev/sg2   | Pengutronix           | usb-sd-mux_rev2.0 | 2.00    | 000000000043
+   /dev/sg3   | Pengutronix           | usb-sd-mux_rev2.0 | 2.00    | 000000000107
+   /dev/sg4   | Linux Automation GmbH | usb-sd-mux_rev4.0 | 2.00    | 000000000757
 
 Using as root
 -------------
@@ -58,9 +61,12 @@ If you just want to try the USB-SD-Mux (or maybe if it is just ok for you) you
 can just use ``usbsdmux`` as root.
 
 If you have installed this tool inside a virtualenv you can just call the
-shell-wrapper with something like
-``sudo /path/to/virtualenv/bin/usbsdmux /dev/sg1 DUT``.
+shell-wrapper along with the appropriate `/dev/sg*` device path:
 
+.. code-block:: bash
+
+   sudo /path/to/virtualenv/bin/usbsdmux /dev/sg1 dut
+   sudo /path/to/virtualenv/bin/usbsdmux /dev/sg1 host
 
 Using as non-root user
 ----------------------

--- a/usbsdmux/__main__.py
+++ b/usbsdmux/__main__.py
@@ -25,8 +25,8 @@ import json
 import socket
 import os
 
-def direct_mode(sg, mode):
-    ctl = UsbSdMux(sg)
+def direct_mode(sg, mode, validate_usb=True):
+    ctl = UsbSdMux(sg, validate_usb)
 
     if mode.lower() == "off":
         ctl.mode_disconnect()
@@ -78,6 +78,12 @@ def main():
         action="store_true",
         default=False)
     parser.add_argument(
+        "-f",
+        "--force",
+        help=argparse.SUPPRESS,
+        action="store_true",
+        default=False)
+    parser.add_argument(
         "-s",
         "--socket",
         help="Overrides the default socket for client mode.",
@@ -92,10 +98,10 @@ def main():
     if args.client is True:
         client_mode(args.sg, args.mode, args.socket)
     elif args.direct is True:
-        direct_mode(args.sg, args.mode)
+        direct_mode(args.sg, args.mode, not args.force)
     else:
         if os.getresuid()[0] == 0:
-            direct_mode(args.sg, args.mode)
+            direct_mode(args.sg, args.mode, not args.force)
         else:
             client_mode(args.sg, args.mode, args.socket)
 

--- a/usbsdmux/__main__.py
+++ b/usbsdmux/__main__.py
@@ -25,6 +25,23 @@ import json
 import socket
 import os
 
+def list_mode():
+    muxes = UsbSdMux.enumerate()
+
+    header = {
+        'path': 'Path',
+        'manufacturer' : 'Manufacturer',
+        'product' : 'Product',
+        'version' : 'Version',
+        'serial' : 'Serial'
+    }
+
+    for mux in [header] + muxes:
+        print('{:10} | {:21} | {:17} | {:7} | {:12}'.format(
+            mux['path'], mux['manufacturer'], mux['product'],
+            mux['version'], mux['serial']
+        ))
+
 def direct_mode(sg, mode, validate_usb=True):
     ctl = UsbSdMux(sg, validate_usb)
 
@@ -59,12 +76,13 @@ def client_mode(sg, mode, socket_path):
 def main():
     parser = argparse.ArgumentParser()
 
-    parser.add_argument("sg", metavar="SG", help="/dev/sg* to use")
+    parser.add_argument("sg", metavar="<SG>/list", help="/dev/sg* device to use. Or \"list\" to show available devices")
     parser.add_argument(
         "mode",
         help="mode to switch to",
         choices=["dut", "host", "off", "client"],
-        type=str.lower)
+        type=str.lower,
+        nargs='?')
     parser.add_argument(
         "-d",
         "--direct",
@@ -90,6 +108,14 @@ def main():
         default="/tmp/sdmux.sock")
 
     args = parser.parse_args()
+
+    if args.sg == 'list':
+        list_mode()
+        exit(0)
+
+    if args.mode not in ("dut", "host", "off", "client"):
+        print("Mode must be either dut, host, off or client. Exiting", file=sys.stderr)
+        exit(1)
 
     if args.client is True and args.direct is True:
         print("Can not run in direct and client mode at the same time. Exiting.", file=sys.stderr)

--- a/usbsdmux/pca9536.py
+++ b/usbsdmux/pca9536.py
@@ -44,16 +44,18 @@ class Pca9536(object):
   _direction_output = 0
   _direction_input = 1
 
-  def __init__(self, sg):
+  def __init__(self, sg, validate_usb=True):
     """
     Create a new Pca9536-controller.
 
     Arguments:
     sg -- /dev/sg* to use.
+    validate_usb -- Check if the USB descriptor fields of the sg device match known
+                    USB-SD-Muxes values.
     """
-    self.sg = sg
 
-    self._usb = Usb2642I2C(sg)
+    self._usb = Usb2642I2C(sg, validate_usb)
+    self.sg = sg
 
     # After POR all Pins are Inputs. This value will from now on mirror the
     # value of die _register_configuration

--- a/usbsdmux/service.py
+++ b/usbsdmux/service.py
@@ -158,7 +158,7 @@ def main():
             conn, addr = sock.accept()
             answer = process_request(
                 conn.recv(4096).decode(),
-                not self.force
+                not args.force
             )
             conn.send(answer.encode())
             conn.close()

--- a/usbsdmux/usb2642eeprom.py
+++ b/usbsdmux/usb2642eeprom.py
@@ -43,7 +43,7 @@ class USB2642Eeprom(object):
   Provides an interface to write the configuration EEPROM of a USB2642.
   """
 
-  def __init__(self, sg, i2c_addr=0x50):
+  def __init__(self, sg, i2c_addr=0x50, validate_usb=False):
     """"
     Create a new USB2642Eeprom Instance.
 
@@ -51,9 +51,12 @@ class USB2642Eeprom(object):
     sg -- /dev/sg* to use
     i2c_addr -- 7-Bit Address of the EEPROM to use. Defaults to 0x50 for the
                 configuration-EEPROM. You probably do NOT want to override this.
+    validate_usb -- Check if the USB descriptor fields of the sg device match known
+                    USB-SD-Muxes values. By default do'nt, as this tool is used
+                    to initially write these values.
     """
 
-    self.i2c = Usb2642I2C(sg)
+    self.i2c = Usb2642I2C(sg, validate_usb)
     self.addr = i2c_addr
 
   class _EepromStruct(ctypes.Structure):

--- a/usbsdmux/usbsdmux.py
+++ b/usbsdmux/usbsdmux.py
@@ -20,7 +20,7 @@
 
 from .pca9536 import Pca9536
 import time
-
+import glob
 
 class UsbSdMux(object):
   """
@@ -58,6 +58,23 @@ class UsbSdMux(object):
     self._pca.set_pin_to_output(
         Pca9536.gpio_0 | Pca9536.gpio_1 |
         Pca9536.gpio_2 | Pca9536.gpio_3)
+
+  @classmethod
+  def enumerate(cls):
+    usb_sd_muxes = list()
+
+    for sg in glob.glob('/dev/sg*'):
+      try:
+        usb_sd_muxes.append(Pca9536(sg, True)._usb.read_usb_fields(
+            ('idVendor', 'idProduct', 'manufacturer', 'product', 'version', 'serial')
+        ))
+
+        usb_sd_muxes[-1]['path'] = sg
+
+      except:
+        pass
+
+    return usb_sd_muxes
 
   def mode_disconnect(self, wait=True):
     """

--- a/usbsdmux/usbsdmux.py
+++ b/usbsdmux/usbsdmux.py
@@ -39,14 +39,16 @@ class UsbSdMux(object):
   _card_inserted = 0x00
   _card_removed = Pca9536.gpio_3
 
-  def __init__(self, sg):
+  def __init__(self, sg, validate_usb=True):
     """
     Create a new UsbSdMux.
 
     Arguments:
     sg -- /dev/sg* to use
+    validate_usb -- Check if the USB descriptor fields of the sg device match known
+                    USB-SD-Muxes values.
     """
-    self._pca = Pca9536(sg)
+    self._pca = Pca9536(sg, validate_usb)
 
     # setting the output-values to defaults before enabling outputs on the
     # GPIO-expander
@@ -106,4 +108,3 @@ class UsbSdMux(object):
     # now connect data and power
     self._pca.output_values(self._DAT_enable | self._PWR_enable |
                             self._select_HOST | self._card_inserted)
-


### PR DESCRIPTION
This commit uses the USB-Descriptor handling code introduced for the `sg` device validation to add a `list` sub-command to the `usbsdmux` command.

This pull request is built on top of pull request #33.