### PR TITLE
Add stdeb configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ dist/
 *.venv
 .tox/
 envs/
+deb_dist/
+usbsdmux-*.tar.gz

--- a/copyright.debian
+++ b/copyright.debian
@@ -1,0 +1,12 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: usbsdmux
+Upstream-Contact: info@linux-automation.com
+Source: https://github.com/linux-automation/usbsdmux
+
+Files: *
+Copyright: 2017-2021, Pengutronix <entwicklung@pengutronix.de>
+License: LGPL-2.1+
+
+Files: ./fastentrypoints.py
+Copyright: 2016, Aaron Christianson
+License: BSD-2-clause

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,6 @@ classifiers =
     Natural Language :: English
     Operating System :: Unix
     Programming Language :: Python :: 3 :: Only
+
+[global]
+command-packages: stdeb.command

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,0 +1,3 @@
+[DEFAULT]
+Copyright-File: copyright.debian
+Udev-Rules: contrib/udev/99-usbsdmux.rules


### PR DESCRIPTION
Adds a configuration for [stdeb](https://pypi.org/project/stdeb/), a Python to Debian source package conversion utility.

stdeb can be used to directly create Debian packages for local installations:

    $ python setup.py bdist_deb

However, it can also create a `debian` source folder that can be checked in and maintained separately:

    $ python setup.py debianize

It should be possible to turn this into an upstream Debian package with minimal modifications (e.g. fixing the description, see Lintian output), likely with the help of [gbp](http://honk.sigxcpu.org/projects/git-buildpackage/manual-html/gbp.html). Would you consider doing this?

**Please be aware of the fact that stdeb currently has a bug preventing the udev rule from ending up in the package. I have filed a [pull request](https://github.com/astraw/stdeb/pull/180) to fix this; for now you just might want to take a look at my pre-built [`debian-source` branch](https://github.com/sephalon/usbsdmux/tree/debian-source).**