### PR TITLE
commandline: 'get' must respect hardware signal priority

### DIFF
--- a/usbsdmux/usbsdmux.py
+++ b/usbsdmux/usbsdmux.py
@@ -53,11 +53,15 @@ class UsbSdMux(object):
     Returns currently selected mode as string
     """
     val = self._pca.read_register(1)[0]
+
+    # If the SD-Card is disabled we do not need to check for the selected mode.
+    # PWR_disable and DAT_disable are always switched at the same time.
+    # Let's assume it is sufficient to check one of both.
+    if val & self._PWR_disable:
+      return "off"
+
     if val & self._select_DUT:
        return "dut"
-    if val & self._PWR_disable:
-       return "off"
-
     return "host"
 
   def mode_disconnect(self, wait=True):


### PR DESCRIPTION
The previous implementation of this function did not correctly report
the off-state. Even if the device itself was off this function reported
the USB-SD-Mux to be in "dut-mode".

With this change the actual preference in hardware is respected.
In hardware the PWR_disable and DAT_disable signal has priority over the
switch-state selection.
Thus we need to check the disable-bit first. Only if disable is not set
we can be in dut- or host-mode.

Signed-off-by: Chris Fiege <cfi@pengutronix.de>