### PR TITLE
Do not create if device node does not exist

### DIFF
--- a/usbsdmux/usb2642i2c.py
+++ b/usbsdmux/usb2642i2c.py
@@ -334,7 +334,7 @@ class Usb2642I2C(object):
 #    print("SGIO:")
 #    print(self.to_pretty_hex(sgio))
 
-    with open(self.sg, 'w+b', buffering=0) as fh:
+    with open(self.sg, 'r+b', buffering=0) as fh:
       rc =  fcntl.ioctl(fh, self._SG_IO, sgio)
       if rc != 0:
         raise IoctlFailed("SG_IO ioctl() failed with non-zero exit-code {}"\


### PR DESCRIPTION
This PR fixes a bug in which a file is created in ``/dev/`` instead of a device node when the ``usbsdmux``-tool is called as root with a non-existing ``/dev/sg*`` parameter.

And while I was on it i also improved the error handling in the CLI. With this change the CLI only print the error message if a well-known Exception occurs.