### PR TITLE
contrib/udev: extend /dev/sg match pattern from sg[0-9] to sg[0-9]*

### DIFF
--- a/contrib/udev/99-usbsdmux.rules
+++ b/contrib/udev/99-usbsdmux.rules
@@ -1,3 +1,3 @@
 # USB-SD-Mux
-ACTION=="add", SUBSYSTEM=="scsi_generic", KERNEL=="sg[0-9]", ATTRS{manufacturer}=="Pengutronix", ATTRS{product}=="usb-sd-mux*", SYMLINK="usb-sd-mux/id-$attr{serial}", TAG+="uaccess", GROUP="plugdev"
-ACTION=="add", SUBSYSTEM=="scsi_generic", KERNEL=="sg[0-9]", ATTRS{manufacturer}=="Linux Automation GmbH", ATTRS{product}=="usb-sd-mux*", SYMLINK="usb-sd-mux/id-$attr{serial}", TAG+="uaccess", GROUP="plugdev"
+ACTION=="add", SUBSYSTEM=="scsi_generic", KERNEL=="sg[0-9]*", ATTRS{manufacturer}=="Pengutronix", ATTRS{product}=="usb-sd-mux*", SYMLINK="usb-sd-mux/id-$attr{serial}", TAG+="uaccess", GROUP="plugdev"
+ACTION=="add", SUBSYSTEM=="scsi_generic", KERNEL=="sg[0-9]*", ATTRS{manufacturer}=="Linux Automation GmbH", ATTRS{product}=="usb-sd-mux*", SYMLINK="usb-sd-mux/id-$attr{serial}", TAG+="uaccess", GROUP="plugdev"


### PR DESCRIPTION
Not only match /dev/sg0 to /dev/sg9, but also higher IDs like /dev/sg12.

Signed-off-by: Andreas Pretzsch <apr@cn-eng.de>