### PR TITLE
`flake8` and `black`: Fix Problems and add Actions for verification

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,14 @@
+name: black
+
+on: [push, pull_request]
+
+jobs:
+  python-black:
+    name: Python Black
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Python Black
+        uses: cytopia/docker-black@0.8
+        with:
+          path: '.'

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,25 @@
+name: flake8 
+
+on: [push, pull_request]
+
+jobs:
+  flake8_py3:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.9
+          architecture: x64
+      - name: Install flake8
+        run: |
+          pip install --upgrade pip
+          pip install -r REQUIREMENTS.qa.txt
+      - name: Run flake8
+        uses: suo/flake8-github-action@releases/v1
+        with:
+          checkName: 'flake8_py3'   # NOTE: this needs to be the same as the job name
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 *.venv
 .tox/
 envs/
+.idea

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ PYTHON=python3
 
 PYTHON_ENV_ROOT=envs
 PYTHON_PACKAGING_VENV=$(PYTHON_ENV_ROOT)/$(PYTHON)-packaging-env
+PYTHON_TESTING_ENV=$(PYTHON_ENV_ROOT)/$(PYTHON)-qa-env
 
 .PHONY: clean
 
@@ -30,3 +31,18 @@ clean:
 	rm -rf $(PYTHON_ENV_ROOT)
 
 envs: env packaging-env
+
+# testing #####################################################################
+$(PYTHON_TESTING_ENV)/.created: REQUIREMENTS.qa.txt
+	rm -rf $(PYTHON_TESTING_ENV) && \
+	$(PYTHON) -m venv $(PYTHON_TESTING_ENV) && \
+	. $(PYTHON_TESTING_ENV)/bin/activate && \
+	pip install pip --upgrade && \
+	pip install -r ./REQUIREMENTS.qa.txt && \
+	date > $(PYTHON_TESTING_ENV)/.created
+
+qa: $(PYTHON_TESTING_ENV)/.created
+	. $(PYTHON_TESTING_ENV)/bin/activate && \
+	black --check --diff . && \
+	flake8
+

--- a/REQUIREMENTS.qa.txt
+++ b/REQUIREMENTS.qa.txt
@@ -1,0 +1,5 @@
+black
+flake8
+flake8-pyproject
+flake8-bugbear
+

--- a/fastentrypoints.py
+++ b/fastentrypoints.py
@@ -23,7 +23,7 @@
 # LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-'''
+"""
 Monkey patch setuptools to write faster console_scripts with this format:
 
     import sys
@@ -34,10 +34,11 @@ This is better.
 
 (c) 2016, Aaron Christianson
 http://github.com/ninjaaron/fast-entry_points
-'''
+"""
 from setuptools.command import easy_install
 import re
-TEMPLATE = '''\
+
+TEMPLATE = """\
 # -*- coding: utf-8 -*-
 import re
 import sys
@@ -46,7 +47,7 @@ from {0} import {1}
 
 if __name__ == '__main__':
     sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
-    sys.exit({2}())'''
+    sys.exit({2}())"""
 
 
 @classmethod
@@ -58,14 +59,13 @@ def get_args(cls, dist, header=None):
     if header is None:
         header = cls.get_header()
     spec = str(dist.as_requirement())
-    for type_ in 'console', 'gui':
-        group = type_ + '_scripts'
+    for type_ in "console", "gui":
+        group = type_ + "_scripts"
         for name, ep in dist.get_entry_map(group).items():
             # ensure_safe_name
-            if re.search(r'[\\/]', name):
+            if re.search(r"[\\/]", name):
                 raise ValueError("Path separators not allowed in script names")
-            script_text = TEMPLATE.format(
-                          ep.module_name, ep.attrs[0], '.'.join(ep.attrs))
+            script_text = TEMPLATE.format(ep.module_name, ep.attrs[0], ".".join(ep.attrs))
             args = cls._get_script_args(type_, name, header, script_text)
             for res in args:
                 yield res
@@ -79,29 +79,30 @@ def main():
     import re
     import shutil
     import sys
-    dests = sys.argv[1:] or ['.']
-    filename = re.sub('\.pyc$', '.py', __file__)
+
+    dests = sys.argv[1:] or ["."]
+    filename = re.sub("\.pyc$", ".py", __file__)
 
     for dst in dests:
         shutil.copy(filename, dst)
-        manifest_path = os.path.join(dst, 'MANIFEST.in')
-        setup_path = os.path.join(dst, 'setup.py')
+        manifest_path = os.path.join(dst, "MANIFEST.in")
+        setup_path = os.path.join(dst, "setup.py")
 
         # Insert the include statement to MANIFEST.in if not present
-        with open(manifest_path, 'a+') as manifest:
+        with open(manifest_path, "a+") as manifest:
             manifest.seek(0)
             manifest_content = manifest.read()
-            if not 'include fastentrypoints.py' in manifest_content:
-                manifest.write(('\n' if manifest_content else '')
-                               + 'include fastentrypoints.py')
+            if not "include fastentrypoints.py" in manifest_content:
+                manifest.write(("\n" if manifest_content else "") + "include fastentrypoints.py")
 
         # Insert the import statement to setup.py if not present
-        with open(setup_path, 'a+') as setup:
+        with open(setup_path, "a+") as setup:
             setup.seek(0)
             setup_content = setup.read()
-            if not 'import fastentrypoints' in setup_content:
+            if not "import fastentrypoints" in setup_content:
                 setup.seek(0)
                 setup.truncate()
-                setup.write('import fastentrypoints\n' + setup_content)
+                setup.write("import fastentrypoints\n" + setup_content)
+
 
 print(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.black]
+line-length = 119
+
+[tool.flake8]
+max-line-length = 119
+count = true
+exclude = "build,debian,dist,envs,fastentrypoints.py,__pycache__,contrib,setup.py,venv,usbsdmux.egg-info,.tox"

--- a/setup.py
+++ b/setup.py
@@ -11,15 +11,13 @@ setup(
     license="LGPL-2.1-or-later",
     url="https://github.com/pengutronix/usbsdmux",
     description="Tool to control an usb-sd-mux from the command line",
-    packages=['usbsdmux'],
+    packages=["usbsdmux"],
     entry_points={
-        'console_scripts': [
-            'usbsdmux = usbsdmux.__main__:main',
-            'usbsdmux-configure = usbsdmux.usb2642eeprom:main',
-            'usbsdmux-service = usbsdmux.service:main',
+        "console_scripts": [
+            "usbsdmux = usbsdmux.__main__:main",
+            "usbsdmux-configure = usbsdmux.usb2642eeprom:main",
+            "usbsdmux-service = usbsdmux.service:main",
         ],
     },
-    classifiers=[
-        "License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)"
-    ]
+    classifiers=["License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)"],
 )

--- a/usbsdmux/__main__.py
+++ b/usbsdmux/__main__.py
@@ -24,22 +24,22 @@ import sys
 
 from .usbsdmux import UsbSdMux
 
+
 def main():
-    parser = argparse.ArgumentParser(
-        formatter_class=argparse.RawTextHelpFormatter
-    )
+    parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
 
     parser.add_argument("sg", metavar="SG", help="/dev/sg* to use")
     parser.add_argument(
         "mode",
         help="Action:\n"
-             "get - return selected mode\n"
-             "dut - set to dut mode\n"
-             "client - set to dut mode (alias for dut)\n"
-             "host - set to host mode\n"
-             "off - set to off mode",
+        "get - return selected mode\n"
+        "dut - set to dut mode\n"
+        "client - set to dut mode (alias for dut)\n"
+        "host - set to host mode\n"
+        "off - set to off mode",
         choices=["get", "dut", "client", "host", "off"],
-        type=str.lower)
+        type=str.lower,
+    )
 
     # These arguments were previously used for the client/service
     # based method to grant USB-SD-Mux access to non-root users.
@@ -47,20 +47,19 @@ def main():
     # rules and a change to how the /dev/sg* devices are accessed.
     # Display a warning but do not fail when these are used so
     # existing scripts do not break and can be upgraded gracefully.
-    parser.add_argument("-d", "--direct", help=argparse.SUPPRESS,
-                        action="store_true", default=None)
-    parser.add_argument("-c", "--client", help=argparse.SUPPRESS,
-                        action="store_true", default=None)
-    parser.add_argument("-s", "--socket", help=argparse.SUPPRESS,
-                        default=None)
+    parser.add_argument("-d", "--direct", help=argparse.SUPPRESS, action="store_true", default=None)
+    parser.add_argument("-c", "--client", help=argparse.SUPPRESS, action="store_true", default=None)
+    parser.add_argument("-s", "--socket", help=argparse.SUPPRESS, default=None)
 
     args = parser.parse_args()
 
     if any(arg is not None for arg in (args.direct, args.client, args.socket)):
-        print("usbsdmux: usage of -s/-c/-d arguments is deprecated "
-              "as the service/client split is no longer required. "
-              "Please upgrade your scripts to not supply either of these arguments",
-              file=sys.stderr)
+        print(
+            "usbsdmux: usage of -s/-c/-d arguments is deprecated "
+            "as the service/client split is no longer required. "
+            "Please upgrade your scripts to not supply either of these arguments",
+            file=sys.stderr,
+        )
 
     ctl = UsbSdMux(args.sg)
     mode = args.mode.lower()

--- a/usbsdmux/ctypehelper.py
+++ b/usbsdmux/ctypehelper.py
@@ -20,31 +20,28 @@
 
 import ctypes
 import string
+
 """
 This module contains functions related to packing data into ctype arrays in
 special ways as needed by the Microchip USB2642.
 """
 
 
-def string_to_uint8_array(str,
-                          array_length,
-                          c_string=False,
-                          padding=0xFF,
-                          encoding="UTF-16"):
+def string_to_uint8_array(str, array_length, c_string=False, padding=0xFF, encoding="UTF-16"):
     """
-  Converts a python-string into a ctypes.c_uint8 array of a given length.
+    Converts a python-string into a ctypes.c_uint8 array of a given length.
     The str will be encoded with the given encoding before converting.
 
-  If c_string is True the string will be terminated with 0x00.
-  str will be padded with padding if the buffer is longer than the str.
-  str will be cropped if the buffer is shorter.
+    If c_string is True the string will be terminated with 0x00.
+    str will be padded with padding if the buffer is longer than the str.
+    str will be cropped if the buffer is shorter.
 
-  Arguments:
-  str -- python string
-  array_length -- length of the resulting array in bytes.
-  c_string -- Switch to treat a str as c-string. String will be terminated with 0x00
-  padding -- This value will be used to pad buffer to the given length.
-  """
+    Arguments:
+    str -- python string
+    array_length -- length of the resulting array in bytes.
+    c_string -- Switch to treat a str as c-string. String will be terminated with 0x00
+    padding -- This value will be used to pad buffer to the given length.
+    """
 
     # Preparing output array
     byte_buf = (ctypes.c_uint8 * array_length)()
@@ -72,17 +69,17 @@ def string_to_uint8_array(str,
 
 def string_to_microchip_unicode_uint8_array(text, array_length, constant=0x03):
     """
-  Converts a String to a USB2642 UTF-16 string.
+    Converts a String to a USB2642 UTF-16 string.
 
-  The USB2642 requires the first two bytes of the string to be
-  <length including first two bytes><0x03>.
-  This function first creates a UTF-16 string and then replaces the byte-order
-  mark with this information.
+    The USB2642 requires the first two bytes of the string to be
+    <length including first two bytes><0x03>.
+    This function first creates a UTF-16 string and then replaces the byte-order
+    mark with this information.
 
-  Arguments:
-  text -- Text to copy into the array
-  constant -- The constant byte placed into the 2nd byte
-  """
+    Arguments:
+    text -- Text to copy into the array
+    constant -- The constant byte placed into the 2nd byte
+    """
 
     byte_buf = string_to_uint8_array(text, array_length)
     byte_buf[0] = len(text) * 2 + 2
@@ -92,15 +89,15 @@ def string_to_microchip_unicode_uint8_array(text, array_length, constant=0x03):
 
 def list_to_uint8_array(numbers, array_length):
     """
-  Converts a list of numbers into a ctypes.c_uint8 array of a given length.
+    Converts a list of numbers into a ctypes.c_uint8 array of a given length.
 
-  If numbers is too short for array_length it will be padded with 0x00.
-  If numbers is too long it will be cropped.
+    If numbers is too short for array_length it will be padded with 0x00.
+    If numbers is too long it will be cropped.
 
-  Arguments:
-  numbers -- iterable of numbers (int, bytes, float...)
-  array_length -- length of the resulting array
-  """
+    Arguments:
+    numbers -- iterable of numbers (int, bytes, float...)
+    array_length -- length of the resulting array
+    """
 
     byte_buf = (ctypes.c_uint8 * array_length)()
 
@@ -115,9 +112,7 @@ def to_pretty_hex(buffer):
 
     if isinstance(buffer, ctypes.Structure):
         out = ctypes.create_string_buffer(ctypes.sizeof(buffer))
-        ctypes.memmove(
-            ctypes.addressof(out),
-            ctypes.addressof(buffer), ctypes.sizeof(buffer))
+        ctypes.memmove(ctypes.addressof(out), ctypes.addressof(buffer), ctypes.sizeof(buffer))
         temp_buf = [ord(x) for x in out]
     elif isinstance(buffer[0], int):
         temp_buf = [x for x in buffer]
@@ -129,10 +124,10 @@ def to_pretty_hex(buffer):
     while len(temp_buf) > 0:
         window = temp_buf[0:8]
         temp_buf = temp_buf[8:]
-        res += "0x{:02X}\t{}  {}\n".format(offs, " ".join(
-            ["{:02X}".format(x) for x in window]), " ".join([
-                chr(x) if chr(x) in string.printable.split(" ")[0] else "."
-                for x in window
-            ]))
+        res += "0x{:02X}\t{}  {}\n".format(
+            offs,
+            " ".join(["{:02X}".format(x) for x in window]),
+            " ".join([chr(x) if chr(x) in string.printable.split(" ")[0] else "." for x in window]),
+        )
         offs += 8
     return res

--- a/usbsdmux/pca9536.py
+++ b/usbsdmux/pca9536.py
@@ -22,85 +22,81 @@ from .usb2642i2c import Usb2642I2C
 
 
 class Pca9536(object):
-  """
-  Interface to control a Pca9536 that is connected to the auxiliary-I2C of a
-  Microchip USB2642.
-  """
-
-  # The PCA9536 I2C Slave Address in 7-Bit Format
-  _I2cAddr = 0x41
-
-  # Registers inside the PCA9536
-  _register_inputPort = 0x00
-  _register_outputPort = 0x01
-  _register_polarity = 0x02
-  _register_configuration = 0x03
-
-  gpio_0 = 0x01
-  gpio_1 = 0x02
-  gpio_2 = 0x04
-  gpio_3 = 0x08
-
-  _direction_output = 0
-  _direction_input = 1
-
-  def __init__(self, sg):
     """
-    Create a new Pca9536-controller.
-
-    Arguments:
-    sg -- /dev/sg* to use.
-    """
-    self.sg = sg
-
-    self._usb = Usb2642I2C(sg)
-
-    # After POR all Pins are Inputs. This value will from now on mirror the
-    # value of die _register_configuration
-    self._directionMask = 0xFF
-
-  def _write_register(self, register, value):
-    """
-    Writes a register on the Pca9536 with a given value.
+    Interface to control a Pca9536 that is connected to the auxiliary-I2C of a
+    Microchip USB2642.
     """
 
-    self._usb.write_to(self._I2cAddr, [register, value])
+    # The PCA9536 I2C Slave Address in 7-Bit Format
+    _I2cAddr = 0x41
 
-  def read_register(self, addr, len=1):
-    """
-    Returns a register of the Pca9536.
-    """
-    return self._usb.write_read_to(self._I2cAddr, [addr], len)
+    # Registers inside the PCA9536
+    _register_inputPort = 0x00
+    _register_outputPort = 0x01
+    _register_polarity = 0x02
+    _register_configuration = 0x03
 
-  def set_pin_to_output(self, pins):
-    """
-    Sets the corresponding pins as outputs.
+    gpio_0 = 0x01
+    gpio_1 = 0x02
+    gpio_2 = 0x04
+    gpio_3 = 0x08
 
-    Arguments:
-    pins -- Combination of Pca9536.gpio_*
-    """
+    _direction_output = 0
+    _direction_input = 1
 
-    self._directionMask = self._directionMask & (~pins)
-    self._write_register(self._register_configuration, self._directionMask)
+    def __init__(self, sg):
+        """
+        Create a new Pca9536-controller.
 
-  def set_pin_to_input(self, pins):
-    """
-    Sets the corresponding pins as inputs.
+        Arguments:
+        sg -- /dev/sg* to use.
+        """
+        self.sg = sg
 
-    Arguments:
-    pins -- Combination of Pca9536.gpio_*
-    """
+        self._usb = Usb2642I2C(sg)
 
-    self._directionMask = self._directionMask | pins
-    self._write_register(self._register_configuration, self._directionMask)
+        # After POR all Pins are Inputs. This value will from now on mirror the
+        # value of die _register_configuration
+        self._directionMask = 0xFF
 
-  def output_values(self, values):
-    """
-    Writes the given values to the GPIO-expander.
-    Pins configured as Inputs are not affected by this.
+    def _write_register(self, register, value):
+        """
+        Writes a register on the Pca9536 with a given value.
+        """
+        self._usb.write_to(self._I2cAddr, [register, value])
 
-    Arguments:
-    values -- Combination of Pca9536.gpio_*
-    """
+    def read_register(self, addr, len=1):
+        """
+        Returns a register of the Pca9536.
+        """
+        return self._usb.write_read_to(self._I2cAddr, [addr], len)
 
-    self._write_register(self._register_outputPort, values)
+    def set_pin_to_output(self, pins):
+        """
+        Sets the corresponding pins as outputs.
+
+        Arguments:
+        pins -- Combination of Pca9536.gpio_*
+        """
+        self._directionMask = self._directionMask & (~pins)
+        self._write_register(self._register_configuration, self._directionMask)
+
+    def set_pin_to_input(self, pins):
+        """
+        Sets the corresponding pins as inputs.
+
+        Arguments:
+        pins -- Combination of Pca9536.gpio_*
+        """
+        self._directionMask = self._directionMask | pins
+        self._write_register(self._register_configuration, self._directionMask)
+
+    def output_values(self, values):
+        """
+        Writes the given values to the GPIO-expander.
+        Pins configured as Inputs are not affected by this.
+
+        Arguments:
+        values -- Combination of Pca9536.gpio_*
+        """
+        self._write_register(self._register_outputPort, values)

--- a/usbsdmux/service.py
+++ b/usbsdmux/service.py
@@ -31,6 +31,7 @@ This file is kept here to notify users that have set up a systemd service.
 
 import sys
 
+
 def main():
     print("The usage of usbsdmux-service is deprecated.", file=sys.stderr)
     print("Access to USB-SD-Mux devices is now controlled by a new set of udev rules.", file=sys.stderr)

--- a/usbsdmux/usb2642eeprom.py
+++ b/usbsdmux/usb2642eeprom.py
@@ -25,8 +25,12 @@ import sys
 import time
 
 from .usb2642i2c import Usb2642I2C
-from .ctypehelper import string_to_microchip_unicode_uint8_array,\
-  string_to_uint8_array, list_to_uint8_array, to_pretty_hex
+from .ctypehelper import (
+    string_to_microchip_unicode_uint8_array,
+    string_to_uint8_array,
+    list_to_uint8_array,
+    to_pretty_hex,
+)
 
 
 """
@@ -36,270 +40,265 @@ the configuration-EEPROM of a USB2642 using the USB2642.
 
 
 class VerificationFailedException(Exception):
-  pass
+    pass
 
 
 class USB2642Eeprom(object):
-  """
-  Provides an interface to write the configuration EEPROM of a USB2642.
-  """
-
-  def __init__(self, sg, i2c_addr=0x50):
-    """"
-    Create a new USB2642Eeprom Instance.
-
-    Arguments:
-    sg -- /dev/sg* to use
-    i2c_addr -- 7-Bit Address of the EEPROM to use. Defaults to 0x50 for the
-                configuration-EEPROM. You probably do NOT want to override this.
+    """
+    Provides an interface to write the configuration EEPROM of a USB2642.
     """
 
-    self.i2c = Usb2642I2C(sg)
-    self.addr = i2c_addr
+    def __init__(self, sg, i2c_addr=0x50):
+        """
+        Create a new USB2642Eeprom Instance.
 
-  class _EepromStruct(ctypes.Structure):
-    """
-    Struct that contains the Configuration of the Card Reader and USB Hub.
-    """
-    _pack_ = 1 # forces the struct to be packed tight and overrides the default
-               # 4-byte aligned packing.
-    _fields_ = [
+        Arguments:
+        sg -- /dev/sg* to use
+        i2c_addr -- 7-Bit Address of the EEPROM to use. Defaults to 0x50 for the
+                    configuration-EEPROM. You probably do NOT want to override this.
+        """
+        self.i2c = Usb2642I2C(sg)
+        self.addr = i2c_addr
 
-      # Flash Media Controller Configuration
-      ('USB_SER_NUM', ctypes.c_uint8*(0x19-0x00+1)),    # 0x00  .. 0x19  USB Serial Number
-      ('USB_VID', ctypes.c_uint16),                     # 0x1A  .. 0x1B  USB Vendor ID
-      ('USB_PID', ctypes.c_uint16),                     # 0x1C  .. 0x1D  USB Product ID
-      ('USB_LANG_ID', ctypes.c_uint8*(0x21-0x1E+1)),    # 0x1E  .. 0x21  USB Language Identifier, see http://www.usb.org/developers/docs/USB_LANGIDs.pdf
-      ('USB_MFR_STR', ctypes.c_uint8*(0x5D-0x22+1)),    # 0x22  .. 0x5D  USB Manufacturer String (Unicode)
-      ('USB_PRD_STR', ctypes.c_uint8*(0x99-0x5E+1)),    # 0x5E  .. 0x99  USB Product String (Unicode)
-      ('USB_BM_ATT', ctypes.c_uint8),                   # 0x9A           USB BmAttribute, see http://sdphca.ucsd.edu/lab_equip_manuals/usb_20.pdf, P.266
-      ('USB_MAX_PWR', ctypes.c_uint8),                  # 0x9B           USB Max Power, see http://sdphca.ucsd.edu/lab_equip_manuals/usb_20.pdf, P.266, 1 Digit = 2mA
-      ('ATT_LB', ctypes.c_uint8),                       # 0x9C           Attribute Lo byte
-      ('ATT_HLB', ctypes.c_uint8),                      # 0x9D           Attribute Hi Lo byte
-      ('ATT_LHB', ctypes.c_uint8),                      # 0x9E           Attribute Lo Hi byte
-      ('ATT_HB', ctypes.c_uint8),                       # 0x9F           Attribute Hi byte
-      ('reserved0', ctypes.c_uint8*(0xA4-0xA0)),        # 0xA0  .. 0xA3  reserved
-      ('LUN_PWR_LB', ctypes.c_uint8),                   # 0xA4           LUN Power Lo byte
-      ('LUN_PWR_HB', ctypes.c_uint8),                   # 0xA5           LUN Power Hi byte
-      ('reserved1', ctypes.c_uint8*(0xBF-0xA6)),        # 0xA6  .. 0xBE  reserved
-      ('DEV3_ID_STR', ctypes.c_uint8*(0xC6-0xBF)),      # 0xBF  .. 0xC5  Card Reader Identifyer String
-      ('INQ_VEN_STR', ctypes.c_uint8*(0xCE-0xC6)),      # 0xC6  .. 0xCD  Inquiry Vendor String
-      ('INQ_PRD_STR', ctypes.c_uint8*(0xD3-0xCE)),      # 0xCE  .. 0xD2  48QFN Inquiry Product String
-      ('DYN_NUM_LUN', ctypes.c_uint8),                  # 0xD3           Dynamic Number of LUNs
-      ('LUN_DEV_MAP', ctypes.c_uint8*(0xD8-0xD4)),      # 0xD4  .. 0xD7  LUN to Device Mapping
-      ('reserved2', ctypes.c_uint8*(0xDB-0xD8)),        # 0xD8  .. 0xDA  reserved
+    class _EepromStruct(ctypes.Structure):
+        """
+        Struct that contains the Configuration of the Card Reader and USB Hub.
+        """
 
-      # HUB CONTROLLER CONFIGURATION
-      ('SD_MMC_BUS_TIMING', ctypes.c_uint8*(0xDE-0xDB)),# 0xDB  .. 0xDD  SD/MMC Bus Timing Control
-      ('VID', ctypes.c_uint16),                         # 0xDE  .. 0xDF  Hub Vendor ID
-      ('PID', ctypes.c_uint16),                         # 0xE0  .. 0xE1  Hub Product ID
-      ('DID', ctypes.c_uint16),                         # 0xE2  .. 0xE3  Hub Device ID
-      ('CFG_DAT_BYTE1', ctypes.c_uint8),                # 0xE4           Configuration Data Byte 1
-      ('CFG_DAT_BYTE2', ctypes.c_uint8),                # 0xE5           Configuration Data Byte 2
-      ('CFG_DAT_BYTE3', ctypes.c_uint8),                # 0xE6           Configuration Data Byte 3
-      ('NR_DEVICE', ctypes.c_uint8),                    # 0xE7           Non-Removeable Devices
-      ('PORT_DIS_SP', ctypes.c_uint8),                  # 0xE8           Port Disable (Self)
-      ('PORT_DIS_BP', ctypes.c_uint8),                  # 0xE9           Post Disable (Bus)
-      ('MAX_PWR_SP', ctypes.c_uint8),                   # 0xEA           Max Power (Self)
-      ('MAX_PWR_BP', ctypes.c_uint8),                   # 0xEB           Max Power (Bus)
-      ('HC_MAX_C_SP', ctypes.c_uint8),                  # 0xEC           Hub Controller Max Current (Self)
-      ('HC_MAX_C_BP', ctypes.c_uint8),                  # 0xED           Hub Controller Max Current (Bus)
-      ('PWR_ON_TIME', ctypes.c_uint8),                  # 0xEE           Power-on time
-      ('BOOST_UP', ctypes.c_uint8),                     # 0xEF           Boost_Up
-      ('BOOST_32', ctypes.c_uint8),                     # 0xF0           Boost_3:2
-      ('PRT_SWP', ctypes.c_uint8),                      # 0xF1           Port Swap
-      ('PRTM12', ctypes.c_uint8),                       # 0xF2           Port Map 12
-      ('PRTM3', ctypes.c_uint8),                        # 0xF3           Port Map 3
+        _pack_ = 1  # forces the struct to be packed tight and overrides the default
+        # 4-byte aligned packing.
+        _fields_ = [
+            # Flash Media Controller Configuration
+            ("USB_SER_NUM", ctypes.c_uint8 * (0x19 - 0x00 + 1)),  # 0x00 .. 0x19 USB Serial Number
+            ("USB_VID", ctypes.c_uint16),  # 0x1A .. 0x1B USB Vendor ID
+            ("USB_PID", ctypes.c_uint16),  # 0x1C .. 0x1D USB Product ID
+            (
+                "USB_LANG_ID",
+                ctypes.c_uint8 * (0x21 - 0x1E + 1),
+            ),  # 0x1E  .. 0x21 USB Language Identifier, see http://www.usb.org/developers/docs/USB_LANGIDs.pdf
+            ("USB_MFR_STR", ctypes.c_uint8 * (0x5D - 0x22 + 1)),  # 0x22 .. 0x5D USB Manufacturer String (Unicode)
+            ("USB_PRD_STR", ctypes.c_uint8 * (0x99 - 0x5E + 1)),  # 0x5E .. 0x99 USB Product String (Unicode)
+            (
+                "USB_BM_ATT",
+                ctypes.c_uint8,
+            ),  # 0x9A USB BmAttribute, see http://sdphca.ucsd.edu/lab_equip_manuals/usb_20.pdf, P.266
+            (
+                "USB_MAX_PWR",
+                ctypes.c_uint8,
+            ),  # 0x9B USB Max Power, see http://sdphca.ucsd.edu/lab_equip_manuals/usb_20.pdf, P.266, 1 Digit = 2mA
+            ("ATT_LB", ctypes.c_uint8),  # 0x9C Attribute Lo byte
+            ("ATT_HLB", ctypes.c_uint8),  # 0x9D Attribute Hi Lo byte
+            ("ATT_LHB", ctypes.c_uint8),  # 0x9E Attribute Lo Hi byte
+            ("ATT_HB", ctypes.c_uint8),  # 0x9F Attribute Hi byte
+            ("reserved0", ctypes.c_uint8 * (0xA4 - 0xA0)),  # 0xA0  .. 0xA3 reserved
+            ("LUN_PWR_LB", ctypes.c_uint8),  # 0xA4 LUN Power Lo byte
+            ("LUN_PWR_HB", ctypes.c_uint8),  # 0xA5 LUN Power Hi byte
+            ("reserved1", ctypes.c_uint8 * (0xBF - 0xA6)),  # 0xA6 .. 0xBE reserved
+            ("DEV3_ID_STR", ctypes.c_uint8 * (0xC6 - 0xBF)),  # 0xBF .. 0xC5 Card Reader Identifyer String
+            ("INQ_VEN_STR", ctypes.c_uint8 * (0xCE - 0xC6)),  # 0xC6 .. 0xCD Inquiry Vendor String
+            ("INQ_PRD_STR", ctypes.c_uint8 * (0xD3 - 0xCE)),  # 0xCE .. 0xD2 48QFN Inquiry Product String
+            ("DYN_NUM_LUN", ctypes.c_uint8),  # 0xD3 Dynamic Number of LUNs
+            ("LUN_DEV_MAP", ctypes.c_uint8 * (0xD8 - 0xD4)),  # 0xD4 .. 0xD7 LUN to Device Mapping
+            ("reserved2", ctypes.c_uint8 * (0xDB - 0xD8)),  # 0xD8 .. 0xDA reserved
+            # HUB CONTROLLER CONFIGURATION
+            ("SD_MMC_BUS_TIMING", ctypes.c_uint8 * (0xDE - 0xDB)),  # 0xDB .. 0xDD SD/MMC Bus Timing Control
+            ("VID", ctypes.c_uint16),  # 0xDE .. 0xDF Hub Vendor ID
+            ("PID", ctypes.c_uint16),  # 0xE0 .. 0xE1 Hub Product ID
+            ("DID", ctypes.c_uint16),  # 0xE2 .. 0xE3 Hub Device ID
+            ("CFG_DAT_BYTE1", ctypes.c_uint8),  # 0xE4 Configuration Data Byte 1
+            ("CFG_DAT_BYTE2", ctypes.c_uint8),  # 0xE5 Configuration Data Byte 2
+            ("CFG_DAT_BYTE3", ctypes.c_uint8),  # 0xE6 Configuration Data Byte 3
+            ("NR_DEVICE", ctypes.c_uint8),  # 0xE7 Non-Removeable Devices
+            ("PORT_DIS_SP", ctypes.c_uint8),  # 0xE8 Port Disable (Self)
+            ("PORT_DIS_BP", ctypes.c_uint8),  # 0xE9 Post Disable (Bus)
+            ("MAX_PWR_SP", ctypes.c_uint8),  # 0xEA Max Power (Self)
+            ("MAX_PWR_BP", ctypes.c_uint8),  # 0xEB Max Power (Bus)
+            ("HC_MAX_C_SP", ctypes.c_uint8),  # 0xEC Hub Controller Max Current (Self)
+            ("HC_MAX_C_BP", ctypes.c_uint8),  # 0xED Hub Controller Max Current (Bus)
+            ("PWR_ON_TIME", ctypes.c_uint8),  # 0xEE Power-on time
+            ("BOOST_UP", ctypes.c_uint8),  # 0xEF Boost_Up
+            ("BOOST_32", ctypes.c_uint8),  # 0xF0 Boost_3:2
+            ("PRT_SWP", ctypes.c_uint8),  # 0xF1 Port Swap
+            ("PRTM12", ctypes.c_uint8),  # 0xF2 Port Map 12
+            ("PRTM3", ctypes.c_uint8),  # 0xF3 Port Map 3
+            # OTHER CONFIGURATION
+            ("SD_CLK_LIM", ctypes.c_uint8),  # 0xF4 SD Clock Limit for the Flash Media Controller
+            ("reserved3", ctypes.c_uint8),  # 0xF5 reserved
+            ("MEDIA_SETTINGS", ctypes.c_uint8),  # 0xF6 SD1 Timeout Configuration
+            ("reserved4", ctypes.c_uint8 * (0xFC - 0xF7)),  # 0xF7 .. 0xFB  reserved
+            ("NVSTORE_SIG", ctypes.c_uint8 * (0xFF - 0xFC + 1)),  # 0xFC .. 0xFF  Non-Volatile Storage Signature
+            # Non Volatile Storage 2 Contents
+            ("CLUN0_ID_STR", ctypes.c_uint8 * (0x106 - 0x100 + 1)),  # 0x100 .. 0x106 LUN 0 Identifier String
+            ("CLUN1_ID_STR", ctypes.c_uint8 * (0x10D - 0x107 + 1)),  # 0x107 .. 0x10D LUN 1 Identifier String
+            ("CLUN2_ID_STR", ctypes.c_uint8 * (0x114 - 0x10E + 1)),  # 0x10E .. 0x114 LUN 2 Identifier String
+            ("CLUN3_ID_STR", ctypes.c_uint8 * (0x11B - 0x115 + 1)),  # 0x115 .. 0x11B LUN 3 Identifier String
+            ("CLUN4_ID_STR", ctypes.c_uint8 * (0x122 - 0x11C + 1)),  # 0x11C .. 0x122 LUN 4 Identifier String
+            ("reserved5", ctypes.c_uint8 * (0x145 - 0x123 + 1)),  # 0x123 .. 0x145 reserved
+            ("DYN_NUM_EXT_LUN", ctypes.c_uint8),  # 0x146 Dynamic Number of Extended LUNs
+            ("LUN_DEV_MAP2", ctypes.c_uint8 * (0x14B - 0x147 + 1)),  # 0x147 .. 0x14B LUN to Device mapping
+            ("reserved6", ctypes.c_uint8 * (0x17B - 0x14C + 1)),  # 0x14C .. 0x17B reserved
+            ("NVSTORE_SIG2", ctypes.c_uint8 * (0x17F - 0x17C + 1)),  # 0x17C .. 0x17F Non-Volatile Storage 2 Signature
+        ]
 
-      # OTHER CONFIGURATION
-      ('SD_CLK_LIM', ctypes.c_uint8),                   # 0xF4           SD Clock Limit for the Flash Media Controller
-      ('reserved3', ctypes.c_uint8),                    # 0xF5           reserved
-      ('MEDIA_SETTINGS', ctypes.c_uint8),               # 0xF6           SD1 Timeout Configuration
-      ('reserved4', ctypes.c_uint8*(0xFC-0xF7)),        # 0xF7  .. 0xFB  reserved
-      ('NVSTORE_SIG', ctypes.c_uint8*(0xFF-0xFC+1)),    # 0xFC  .. 0xFF  Non-Volatile Storage Signature
+        def get_struct(
+            reader_VID, reader_PID, reader_vendorString, reader_productString, reader_serial, scsi_mfg, scsi_product
+        ):
+            """
+            Returns a pre-filled EepromStruct.
 
-      # Non Volatile Storage 2 Contents
-      ('CLUN0_ID_STR', ctypes.c_uint8*(0x106-0x100+1)), # 0x100 .. 0x106 LUN 0 Identifier String
-      ('CLUN1_ID_STR', ctypes.c_uint8*(0x10D-0x107+1)), # 0x107 .. 0x10D LUN 1 Identifier String
-      ('CLUN2_ID_STR', ctypes.c_uint8*(0x114-0x10E+1)), # 0x10E .. 0x114 LUN 2 Identifier String
-      ('CLUN3_ID_STR', ctypes.c_uint8*(0x11B-0x115+1)), # 0x115 .. 0x11B LUN 3 Identifier String
-      ('CLUN4_ID_STR', ctypes.c_uint8*(0x122-0x11C+1)), # 0x11C .. 0x122 LUN 4 Identifier String
-      ('reserved5', ctypes.c_uint8*(0x145-0x123+1)),    # 0x123 .. 0x145 reserved
-      ('DYN_NUM_EXT_LUN', ctypes.c_uint8),              # 0x146          Dynamic Number of Extended LUNs
-      ('LUN_DEV_MAP2', ctypes.c_uint8*(0x14B-0x147+1)),  # 0x147 .. 0x14B LUN to Device mapping
-      ('reserved6', ctypes.c_uint8*(0x17B-0x14C+1)),    # 0x14C .. 0x17B reserved
-      ('NVSTORE_SIG2', ctypes.c_uint8*(0x17F-0x17C+1))  # 0x17C .. 0x17F Non-Volatile Storage 2 Signature
-      ]
+            Parameters are taken from the Datasheets defaults if nothing else is
+            mentioned.
+            """
+            s = USB2642Eeprom._EepromStruct(
+                USB_SER_NUM=string_to_microchip_unicode_uint8_array(reader_serial, 0x19 - 0x00 + 1),
+                USB_VID=0x0424,
+                USB_PID=0x4041,
+                USB_LANG_ID=list_to_uint8_array(
+                    [0x04, 0x03, 0x09, 0x04], 0x21 - 0x1E + 1
+                ),  # reverse engineered from actual EEPROM. Does NOT match the datasheet.
+                USB_MFR_STR=string_to_microchip_unicode_uint8_array(reader_vendorString, 0x5D - 0x22 + 1),
+                USB_PRD_STR=string_to_microchip_unicode_uint8_array(reader_productString, 0x99 - 0x5E + 1),
+                USB_BM_ATT=0x80,  # Bus Powered, without Remote wakeup
+                USB_MAX_PWR=0x30,  # 0x30 * 2mA = 96mA Power Consumption
+                ATT_LB=0x50,  # use INQ-strings, SD card is write protected when SW_nWP is high
+                ATT_HLB=0x80,
+                ATT_LHB=0x00,
+                ATT_HB=0x00,
+                LUN_PWR_LB=0x00,
+                LUN_PWR_HB=0x0A,
+                DEV3_ID_STR=string_to_uint8_array("SD/MMC", 0xC5 - 0xBF + 1, encoding="UTF-8", padding=0x00),
+                INQ_VEN_STR=string_to_uint8_array(scsi_mfg, 0xCD - 0xC6 + 1, encoding="UTF-8", padding=0x00),
+                INQ_PRD_STR=string_to_uint8_array(scsi_product, 0xD2 - 0xCE + 1, encoding="UTF-8", padding=0x00),
+                DYN_NUM_LUN=0x01,
+                LUN_DEV_MAP=list_to_uint8_array([0xFF, 0x00, 0x00, 0x00], 0xD7 - 0xD4 + 1),
+                SD_MMC_BUS_TIMING=list_to_uint8_array([0x59, 0x56, 0x97], 0xDD - 0xDB + 1),
+                VID=0x0424,
+                PID=0x2640,
+                DID=0x08A2,
+                CFG_DAT_BYTE1=0x8B,
+                CFG_DAT_BYTE2=0x28,
+                CFG_DAT_BYTE3=0x00,
+                NR_DEVICE=0x02,
+                PORT_DIS_SP=0x0C,  # Disable the unused Downstream-Ports of the hub
+                PORT_DIS_BP=0x0C,  # Disable the unused Downstream-Ports of the hub
+                MAX_PWR_SP=0x01,
+                MAX_PWR_BP=0x32,
+                HC_MAX_C_SP=0x01,
+                HC_MAX_C_BP=0x32,
+                PWR_ON_TIME=0x32,
+                BOOST_UP=0x00,
+                BOOST_32=0x00,
+                PORT_SWP=0x00,
+                PRTM12=0x00,
+                PRTM3=0x00,
+                SD_CLK_LIM=0x00,
+                MEDIA_SETTINGS=0x00,
+                NVSTORE_SIG=string_to_uint8_array("ata2", 4, c_string=False, encoding="UTF-8"),
+                # according to datasheet the signature is "ATA2".
+                # But reverse engineering the configuration written with the microchip-tool shows
+                # that it should be "ata" instead.
+                CLUN0_ID_STR=string_to_uint8_array("COMBO", 0x106 - 0x100 + 1, encoding="UTF-8", padding=0x00),
+                CLUN1_ID_STR=string_to_uint8_array("COMBO", 0x106 - 0x100 + 1, encoding="UTF-8", padding=0x00),
+                CLUN2_ID_STR=string_to_uint8_array("COMBO", 0x106 - 0x100 + 1, encoding="UTF-8", padding=0x00),
+                CLUN3_ID_STR=string_to_uint8_array("COMBO", 0x106 - 0x100 + 1, encoding="UTF-8", padding=0x00),
+                CLUN4_ID_STR=string_to_uint8_array("COMBO", 0x106 - 0x100 + 1, encoding="UTF-8", padding=0x00),
+                DYN_NUM_EXT_LUN=0x00,
+                LUN_DEV_MAP2=list_to_uint8_array([0xFF, 0xFF, 0xFF, 0xFF], 0x14B - 0x147 + 1),
+                NVSTORE_SIG2=string_to_uint8_array("ecf1", 0x17F - 0x17C + 1, encoding="UTF-8", padding=0x00),
+            )
+            assert ctypes.sizeof(s) == 384
+            return s
 
-    def get_struct(reader_VID, reader_PID, reader_vendorString,\
-                   reader_productString, reader_serial, scsi_mfg, scsi_product):
-      """
-      Returns a pre-filled EepromStruct.
+    def _read_EEPROM(self, addr=0, len=256):
+        """
+        Reads len bytes of data starting from addr from the given EEPROM.
 
-      Parameters are taken from the Datasheets defaults if nothing else is
-      mentioned.
-      """
-      s = USB2642Eeprom._EepromStruct(
-        USB_SER_NUM = string_to_microchip_unicode_uint8_array(reader_serial, 0x19-0x00+1),
-        USB_VID = 0x0424,
-        USB_PID = 0x4041,
-        USB_LANG_ID = list_to_uint8_array([0x04, 0x03, 0x09, 0x04], 0x21-0x1E+1), # reverse engineered from actual EEPROM. Does NOT match the datasheet.
-        USB_MFR_STR = string_to_microchip_unicode_uint8_array(reader_vendorString, 0x5D-0x22+1),
-        USB_PRD_STR = string_to_microchip_unicode_uint8_array(reader_productString, 0x99-0x5E+1),
-        USB_BM_ATT = 0x80, # Bus Powered, without Remote wakeup
-        USB_MAX_PWR = 0x30,# 0x30 * 2mA = 96mA Power Consumption
-        ATT_LB = 0x50, # use INQ-strings, SD card is write protected when SW_nWP is high
-        ATT_HLB = 0x80,
-        ATT_LHB = 0x00,
-        ATT_HB = 0x00,
-        LUN_PWR_LB = 0x00,
-        LUN_PWR_HB = 0x0A,
-        DEV3_ID_STR = string_to_uint8_array("SD/MMC", 0xC5-0xBF+1, encoding="UTF-8", padding=0x00),
-        INQ_VEN_STR = string_to_uint8_array(scsi_mfg, 0xCD-0xC6+1, encoding="UTF-8", padding=0x00),
-        INQ_PRD_STR = string_to_uint8_array(scsi_product, 0xD2-0xCE+1, encoding="UTF-8", padding=0x00),
-        DYN_NUM_LUN = 0x01,
-        LUN_DEV_MAP = list_to_uint8_array([0xFF, 0x00, 0x00, 0x00], 0xD7-0xD4+1),
-        SD_MMC_BUS_TIMING = list_to_uint8_array([0x59, 0x56, 0x97], 0xDD-0xDB+1),
-        VID = 0x0424,
-        PID = 0x2640,
-        DID = 0x08A2,
-        CFG_DAT_BYTE1 = 0x8B,
-        CFG_DAT_BYTE2 = 0x28,
-        CFG_DAT_BYTE3 = 0x00,
-        NR_DEVICE = 0x02,
-        PORT_DIS_SP = 0x0C, # Disable the unused Downstream-Ports of the hub
-        PORT_DIS_BP = 0x0C, # Disable the unused Downstream-Ports of the hub
-        MAX_PWR_SP = 0x01,
-        MAX_PWR_BP = 0x32,
-        HC_MAX_C_SP = 0x01,
-        HC_MAX_C_BP = 0x32,
-        PWR_ON_TIME = 0x32,
-        BOOST_UP = 0x00,
-        BOOST_32 = 0x00,
-        PORT_SWP = 0x00,
-        PRTM12 = 0x00,
-        PRTM3 = 0x00,
-        SD_CLK_LIM = 0x00,
-        MEDIA_SETTINGS = 0x00,
-        NVSTORE_SIG = string_to_uint8_array("ata2", 4, c_string=False, encoding="UTF-8"),
-        # according to datasheet the signature is "ATA2".
-        # But reverse engineering the configuration written with the microchip-tool shows that it should be "ata" instead.
-        CLUN0_ID_STR = string_to_uint8_array("COMBO", 0x106-0x100+1, encoding="UTF-8", padding=0x00),
-        CLUN1_ID_STR = string_to_uint8_array("COMBO", 0x106-0x100+1, encoding="UTF-8", padding=0x00),
-        CLUN2_ID_STR = string_to_uint8_array("COMBO", 0x106-0x100+1, encoding="UTF-8", padding=0x00),
-        CLUN3_ID_STR = string_to_uint8_array("COMBO", 0x106-0x100+1, encoding="UTF-8", padding=0x00),
-        CLUN4_ID_STR = string_to_uint8_array("COMBO", 0x106-0x100+1, encoding="UTF-8", padding=0x00),
-        DYN_NUM_EXT_LUN = 0x00,
-        LUN_DEV_MAP2 = list_to_uint8_array([0xFF, 0xFF, 0xFF, 0xFF], 0x14B-0x147+1),
-        NVSTORE_SIG2 = string_to_uint8_array("ecf1", 0x17F-0x17C+1, encoding="UTF-8", padding=0x00)
-      )
-      assert ctypes.sizeof(s) == 384
-      return s
+        Attributes:
+        addr -- Byte address from where to start reading
+        len  -- Number of bytes to read (0..256)
+        """
+        return self.i2c.write_read_to(self.addr, [addr], len)
 
+    def _write_EEPROM(self, addr, data):
+        """
+        Writes data to the EEPROM starting at addr.
 
-  def _read_EEPROM(self, addr=0, len=256):
-    """
-    Reads len bytes of data starting from addr from the given EEPROM.
+        Attributes:
+        addr -- Address to begin write at
+        data -- Iterable containing data to write
+        """
+        offset = 0
+        while offset < len(data):
+            # determine minimum and maximum address to write in this block
+            lower = max((addr + offset) & 0xF0, addr)
+            upper = min(((addr + offset) & 0xF0) | 0x0F, addr + len(data))
 
-    Attributes:
-    addr -- Byte address from where to start reading
-    len  -- Number of bytes to read (0..256)
-    """
+            lowerOffset = lower - addr
+            upperOffset = upper - addr
 
-    return self.i2c.write_read_to(self.addr, [addr], len)
+            self.i2c.write_to(self.addr, [lower] + data[lowerOffset : (upperOffset + 1)])
+            time.sleep(0.1)
+            offset = upperOffset + 1
 
-  def _write_EEPROM(self, addr, data):
-    """
-    Writes data to the EEPROM starting at addr.
+    def write(self, VID, PID, product_string, vendor_string, serial, scsi_mfg, scsi_product):
+        """
+        Writes a configuration to the EEPROM.
 
-    Attributes:
-    addr -- Address to begin write at
-    data -- Iterable containing data to write
-    """
+        Arguments:
+        VID -- USB Vendor ID, uint_16
+        PID -- USB Product ID, uint_16
+        product_string -- Product Name as String
+        vendor_string -- Vendor Name as String
+        serial -- Serial Number, 12 Hex Digits
+        """
+        s = USB2642Eeprom._EepromStruct.get_struct(
+            reader_VID=VID,
+            reader_PID=PID,
+            reader_productString=product_string,
+            reader_vendorString=vendor_string,
+            reader_serial=serial,
+            scsi_mfg=scsi_mfg,
+            scsi_product=scsi_product,
+        )
+        buffer = (ctypes.c_uint8 * ctypes.sizeof(s))()
+        ctypes.memmove(ctypes.addressof(buffer), ctypes.addressof(s), ctypes.sizeof(s))
 
-    offset=0
-    while offset < len(data):
-      #determine minimum and maximum address to write in this block
-      lower = max((addr+offset)&0xF0, addr)
-      upper = min(((addr+offset)&0xF0) | 0x0F, addr + len(data))
+        self.i2c.write_config(buffer)
 
-      lowerOffset = lower-addr
-      upperOffset = upper-addr
-
-      self.i2c.write_to(self.addr, [lower]+data[lowerOffset:(upperOffset+1)])
-      time.sleep(0.1)
-      offset = upperOffset+1
-
-  def write(self, VID, PID, product_string, vendor_string, serial, scsi_mfg,\
-            scsi_product):
-    """
-    Writes a configuration to the EEPROM.
-
-    Arguments:
-    VID -- USB Vendor ID, uint_16
-    PID -- USB Product ID, uint_16
-    product_string -- Product Name as String
-    vendor_string -- Vendor Name as String
-    serial -- Serial Number, 12 Hex Digits
-    """
-
-    s = USB2642Eeprom._EepromStruct.get_struct(
-      reader_VID=VID,
-      reader_PID=PID,
-      reader_productString=product_string,
-      reader_vendorString=vendor_string,
-      reader_serial = serial,
-      scsi_mfg = scsi_mfg,
-      scsi_product = scsi_product
-    )
-    buffer = (ctypes.c_uint8*ctypes.sizeof(s))()
-    ctypes.memmove(ctypes.addressof(buffer), ctypes.addressof(s),\
-                   ctypes.sizeof(s))
-
-    self.i2c.write_config(buffer)
 
 def main():
-  parser = argparse.ArgumentParser(description=\
-             "This tool writes and verifies the configuration EEPROM of the usb-sd-mux with the information given on the command line.")
-  parser.add_argument("sg",\
-                      help="The /dev/sg* which is used.")
-  parser.add_argument("--productString",\
-                      help="Sets the product name that will be written.",\
-                      default="usb-sd-mux_rev1")
-  parser.add_argument("--manufacturerString",\
-                      help="Sets the manufacturerString that will be written.",\
-                      default="Pengutronix")
-  parser.add_argument("--VID",\
-                      help="Sets the VID that will be written.",\
-                      default="0x0424")
-  parser.add_argument("--ScsiManufacturer",\
-                      help="Sets the ScsiManufacturer that will be written.",\
-                      default="PTX")
-  parser.add_argument("--ScsiProduct",\
-                      help="Sets the ScsiProduct that will be written.",\
-                      default="sdmux")
-  parser.add_argument("--PID",\
-                      help="Sets the USB-PIC that will be written.",\
-                      default="0x4041")
-  parser.add_argument("serial",\
-                      help="Sets the Serial Number that will be written.")
+    parser = argparse.ArgumentParser(
+        description="This tool writes and verifies the configuration EEPROM of the usb-sd-mux with the information given on the command line."
+    )
+    parser.add_argument("sg", help="The /dev/sg* which is used.")
+    parser.add_argument(
+        "--productString", help="Sets the product name that will be written.", default="usb-sd-mux_rev1"
+    )
+    parser.add_argument(
+        "--manufacturerString", help="Sets the manufacturerString that will be written.", default="Pengutronix"
+    )
+    parser.add_argument("--VID", help="Sets the VID that will be written.", default="0x0424")
+    parser.add_argument("--ScsiManufacturer", help="Sets the ScsiManufacturer that will be written.", default="PTX")
+    parser.add_argument("--ScsiProduct", help="Sets the ScsiProduct that will be written.", default="sdmux")
+    parser.add_argument("--PID", help="Sets the USB-PIC that will be written.", default="0x4041")
+    parser.add_argument("serial", help="Sets the Serial Number that will be written.")
 
-  args = parser.parse_args()
+    args = parser.parse_args()
 
-  c = USB2642Eeprom(args.sg)
+    c = USB2642Eeprom(args.sg)
 
-  c.write(
-    VID=int(args.VID, base=16),
-    PID=int(args.PID, base=16),
-    product_string=args.productString,
-    vendor_string=args.manufacturerString,
-    serial = args.serial,
-    scsi_mfg = args.ScsiManufacturer,
-    scsi_product = args.ScsiProduct
-  )
+    c.write(
+        VID=int(args.VID, base=16),
+        PID=int(args.PID, base=16),
+        product_string=args.productString,
+        vendor_string=args.manufacturerString,
+        serial=args.serial,
+        scsi_mfg=args.ScsiManufacturer,
+        scsi_product=args.ScsiProduct,
+    )
 
-  print("Write completed")
+    print("Write completed")
 
 
 if __name__ == "__main__":
-  main()
+    main()

--- a/usbsdmux/usb2642eeprom.py
+++ b/usbsdmux/usb2642eeprom.py
@@ -20,18 +20,14 @@
 
 import argparse
 import ctypes
-import struct
-import sys
 import time
 
-from .usb2642i2c import Usb2642I2C
 from .ctypehelper import (
     string_to_microchip_unicode_uint8_array,
     string_to_uint8_array,
     list_to_uint8_array,
-    to_pretty_hex,
 )
-
+from .usb2642i2c import Usb2642I2C
 
 """
 This module provides the high-level interface needed to write the contents of
@@ -236,7 +232,7 @@ class USB2642Eeprom(object):
             lowerOffset = lower - addr
             upperOffset = upper - addr
 
-            self.i2c.write_to(self.addr, [lower] + data[lowerOffset : (upperOffset + 1)])
+            self.i2c.write_to(self.addr, [lower] + data[lowerOffset : (upperOffset + 1)])  # noqa: E203
             time.sleep(0.1)
             offset = upperOffset + 1
 
@@ -268,7 +264,8 @@ class USB2642Eeprom(object):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="This tool writes and verifies the configuration EEPROM of the usb-sd-mux with the information given on the command line."
+        description="This tool writes and verifies the configuration EEPROM of the usb-sd-mux "
+        "with the information given on the command line."
     )
     parser.add_argument("sg", help="The /dev/sg* which is used.")
     parser.add_argument(

--- a/usbsdmux/usb2642i2c.py
+++ b/usbsdmux/usb2642i2c.py
@@ -20,8 +20,12 @@
 
 import ctypes
 import fcntl
-from .ctypehelper import string_to_microchip_unicode_uint8_array,\
-  string_to_uint8_array, list_to_uint8_array, to_pretty_hex
+from .ctypehelper import (
+    string_to_microchip_unicode_uint8_array,
+    string_to_uint8_array,
+    list_to_uint8_array,
+    to_pretty_hex,
+)
 
 
 """
@@ -31,426 +35,421 @@ I2C-busses of the Microchip USB2642.
 
 
 class FrameLengthException(Exception):
-  pass
+    pass
+
 
 class IoctlFailed(Exception):
-  pass
+    pass
+
 
 class I2cTransactionFailed(Exception):
-  pass
+    pass
 
 
 class Usb2642I2C(object):
-  """
-  This class provides an interface to interact with devices on a Microchip
-  USB2642 auxiliary I2C Bus and to write configuration to an EEPROM on the
-  configuration I2C Bus.
-
-  To do so it uses vendor specific SCSI-commands on the mass-storage device
-  provided by the USB2642.
-  Documentation to this behavior can be found in this documents:
-
-  * 'Microchip: I2C_Over_USB_UserGuilde_50002283A.pdf' (Can be found in the
-    (Windows-) software example provided on the components webpage)
-  * The USB2641 datasheet
-  * see http://www.microchip.com/wwwproducts/en/USB2642 for both documents
-
-  Some more interesting links:
-
-  * USB Mass Storage Bulk Transfer Profile Specification:
-    http://www.usb.org/developers/docs/devclass_docs/usbmassbulk_10.pdf
-  * Linux SG_IO ioctl() control structure:
-    http://www.tldp.org/HOWTO/SCSI-Generic-HOWTO/sg_io_hdr_t.html
-  * Denton Gentry's blog post about how to use the sg ioctl() from python:
-    http://codingrelic.geekhold.com/2012/02/ata-commands-in-python.html
-    This article uses it to make ATA-passthrough - beware that we do not use
-    ATA-passthrough here.
-
-
-  This class uses the /dev/sg* -Interface to access the SCSI-device even if no
-  media is present.
-  Make sure you have rw-rights :)
-  """
-
-  def __init__(self, sg):
     """
-    Create a new USB2642I2C-Interface wrapper.
+    This class provides an interface to interact with devices on a Microchip
+    USB2642 auxiliary I2C Bus and to write configuration to an EEPROM on the
+    configuration I2C Bus.
 
-    Arguments:
-    sg -- The sg-device to use. E.g. "/dev/sg1"
-    """
-    self.sg = sg
+    To do so it uses vendor specific SCSI-commands on the mass-storage device
+    provided by the USB2642.
+    Documentation to this behavior can be found in this documents:
+
+    * 'Microchip: I2C_Over_USB_UserGuilde_50002283A.pdf' (Can be found in the
+      (Windows-) software example provided on the components webpage)
+    * The USB2641 datasheet
+    * see http://www.microchip.com/wwwproducts/en/USB2642 for both documents
+
+    Some more interesting links:
+
+    * USB Mass Storage Bulk Transfer Profile Specification:
+      http://www.usb.org/developers/docs/devclass_docs/usbmassbulk_10.pdf
+    * Linux SG_IO ioctl() control structure:
+      http://www.tldp.org/HOWTO/SCSI-Generic-HOWTO/sg_io_hdr_t.html
+    * Denton Gentry's blog post about how to use the sg ioctl() from python:
+      http://codingrelic.geekhold.com/2012/02/ata-commands-in-python.html
+      This article uses it to make ATA-passthrough - beware that we do not use
+      ATA-passthrough here.
 
 
-  class _SgioHdrStruct(ctypes.Structure):
-    """
-    Structure used to access the ioctl() to send arbitrary SCSI-commands.
-
-    Reflects the Kernel-Struct from:
-    <scsi/sg.h> sg_io_hdr_t.
+    This class uses the /dev/sg* -Interface to access the SCSI-device even if no
+    media is present.
+    Make sure you have rw-rights :)
     """
 
-    _fields_ = [
-        ('interface_id', ctypes.c_int),
-        ('dxfer_direction', ctypes.c_int),
-        ('cmd_len', ctypes.c_ubyte),
-        ('mx_sb_len', ctypes.c_ubyte),
-        ('iovec_count', ctypes.c_ushort),
-        ('dxfer_len', ctypes.c_uint),
-        ('dxferp', ctypes.c_void_p),
-        ('cmdp', ctypes.c_void_p),
-        ('sbp', ctypes.c_void_p),
-        ('timeout', ctypes.c_uint),
-        ('flags', ctypes.c_uint),
-        ('pack_id', ctypes.c_int),
-        ('usr_ptr', ctypes.c_void_p),
-        ('status', ctypes.c_ubyte),
-        ('masked_status', ctypes.c_ubyte),
-        ('msg_status', ctypes.c_ubyte),
-        ('sb_len_wr', ctypes.c_ubyte),
-        ('host_status', ctypes.c_ushort),
-        ('driver_status', ctypes.c_ushort),
-        ('resid', ctypes.c_int),
-        ('duration', ctypes.c_uint),
-        ('info', ctypes.c_uint)]
+    def __init__(self, sg):
+        """
+        Create a new USB2642I2C-Interface wrapper.
 
-  # sg_io_hdr_t contains 9 ints, 3 short ints, 6 chars and 4 pointers. So its
-  # size is 9 * 4 + 3 * 2 + 6 * 1 + 4 * 4 = 64 on 32 bit architectures. On 64
-  # bit architectures there are two holes in the struct:
-  # - 4 bytes before *usr_ptr to make the pointer aligned
-  # - 4 bytes at the end to make the size a multiple of 8.
-  # So the size there is: 9 * 4 + 3 * 2 + 6 * 1 + 4 * 8 + 2 * 4 = 88.
-  if ctypes.sizeof(ctypes.c_void_p) == 4:
-    assert ctypes.sizeof(_SgioHdrStruct) == 64
-  else:
-    assert ctypes.sizeof(ctypes.c_void_p) == 8
-    assert ctypes.sizeof(_SgioHdrStruct) == 88
+        Arguments:
+        sg -- The sg-device to use. E.g. "/dev/sg1"
+        """
+        self.sg = sg
 
-  """IOCTL for SG_IO"""
-  _SG_IO = 0x2285  # <scsi/sg.h>
+    class _SgioHdrStruct(ctypes.Structure):
+        """
+        Structure used to access the ioctl() to send arbitrary SCSI-commands.
 
-  """SgioHdr dxfer direction constant: No direction"""
-  _SG_DXFER_NONE = -1
+        Reflects the Kernel-Struct from:
+        <scsi/sg.h> sg_io_hdr_t.
+        """
 
-  """SgioHdr dxfer direction constant: Host to device"""
-  _SG_DXFER_TO_DEV = -2
+        _fields_ = [
+            ("interface_id", ctypes.c_int),
+            ("dxfer_direction", ctypes.c_int),
+            ("cmd_len", ctypes.c_ubyte),
+            ("mx_sb_len", ctypes.c_ubyte),
+            ("iovec_count", ctypes.c_ushort),
+            ("dxfer_len", ctypes.c_uint),
+            ("dxferp", ctypes.c_void_p),
+            ("cmdp", ctypes.c_void_p),
+            ("sbp", ctypes.c_void_p),
+            ("timeout", ctypes.c_uint),
+            ("flags", ctypes.c_uint),
+            ("pack_id", ctypes.c_int),
+            ("usr_ptr", ctypes.c_void_p),
+            ("status", ctypes.c_ubyte),
+            ("masked_status", ctypes.c_ubyte),
+            ("msg_status", ctypes.c_ubyte),
+            ("sb_len_wr", ctypes.c_ubyte),
+            ("host_status", ctypes.c_ushort),
+            ("driver_status", ctypes.c_ushort),
+            ("resid", ctypes.c_int),
+            ("duration", ctypes.c_uint),
+            ("info", ctypes.c_uint),
+        ]
 
-  """SgioHdr dxfer direction constant: Device to Host"""
-  _SG_DXFER_FROM_DEV = -3
+    # sg_io_hdr_t contains 9 ints, 3 short ints, 6 chars and 4 pointers. So its
+    # size is 9 * 4 + 3 * 2 + 6 * 1 + 4 * 4 = 64 on 32 bit architectures. On 64
+    # bit architectures there are two holes in the struct:
+    # - 4 bytes before *usr_ptr to make the pointer aligned
+    # - 4 bytes at the end to make the size a multiple of 8.
+    # So the size there is: 9 * 4 + 3 * 2 + 6 * 1 + 4 * 8 + 2 * 4 = 88.
+    if ctypes.sizeof(ctypes.c_void_p) == 4:
+        assert ctypes.sizeof(_SgioHdrStruct) == 64
+    else:
+        assert ctypes.sizeof(ctypes.c_void_p) == 8
+        assert ctypes.sizeof(_SgioHdrStruct) == 88
 
-  """
-  This Opcode represents a vendor specific SCSI command.
-  According to: 'Microchip: I2C_Over_USB_UserGuilde_50002283A.pdf' P.20
-  """
-  _USB2642SCSIOPCODE = 0xCF
+    """IOCTL for SG_IO"""
+    _SG_IO = 0x2285  # <scsi/sg.h>
 
-  """
-  This Vendor Action marks an I2C Write Action
-  According to: 'Microchip: I2C_Over_USB_UserGuilde_50002283A.pdf' P.20
-  """
-  _USB2642I2CWRITESTREAM = 0x23
+    """SgioHdr dxfer direction constant: No direction"""
+    _SG_DXFER_NONE = -1
 
-  """
-  This Vendor Action marks an I2C Write-Read Action
-  According to: 'Microchip: I2C_Over_USB_UserGuilde_50002283A.pdf' P.20
-  """
-  _USB2642I2CWRITEREADSTREAM = 0x22
+    """SgioHdr dxfer direction constant: Host to device"""
+    _SG_DXFER_TO_DEV = -2
 
-  class _USB2642I2cWriteStruct(ctypes.Structure):
-    """I2C-Write Data Structure for up to 512 Bytes of Data
+    """SgioHdr dxfer direction constant: Device to Host"""
+    _SG_DXFER_FROM_DEV = -3
 
+    """
+    This Opcode represents a vendor specific SCSI command.
     According to: 'Microchip: I2C_Over_USB_UserGuilde_50002283A.pdf' P.20
     """
+    _USB2642SCSIOPCODE = 0xCF
 
-    _fields_ = [
-      ("ScsiVendorCommand", ctypes.c_uint8),
-      ("ScsiVendorActionWriteI2C", ctypes.c_uint8),
-      ("I2cSlaveAddress", ctypes.c_uint8),
-      ("I2cUnused", ctypes.c_uint8),
-      ("I2cDataPhaseLenHigh", ctypes.c_uint8),
-      ("I2cDataPhaseLenLow", ctypes.c_uint8),
-      ("I2cCommandPhaseLen", ctypes.c_uint8),
-      ("I2cCommandPayload", ctypes.c_uint8 * 9)
-    ]
-
-  assert ctypes.sizeof(_USB2642I2cWriteStruct) == 16
-
-  class _USB2642I2cReadStruct(ctypes.Structure):
     """
-    I2C-Read Data Structure for up to 512 Bytes of Data.
-
+    This Vendor Action marks an I2C Write Action
     According to: 'Microchip: I2C_Over_USB_UserGuilde_50002283A.pdf' P.20
     """
+    _USB2642I2CWRITESTREAM = 0x23
 
-    _fields_ = [
-      ("ScsiVendorCommand", ctypes.c_uint8),
-      ("ScsiVendorActionWriteReadI2C", ctypes.c_uint8),
-      ("I2cWriteSlaveAddress", ctypes.c_uint8),
-      ("I2cReadSlaveAddress", ctypes.c_uint8),
-      ("I2cReadPhaseLenHigh", ctypes.c_uint8),
-      ("I2cReadPhaseLenLow", ctypes.c_uint8),
-      ("I2cWritePhaseLen", ctypes.c_uint8),
-      ("I2cWritePayload", ctypes.c_uint8 * 9)
-    ]
-
-  assert ctypes.sizeof(_USB2642I2cReadStruct) == 16
-
-
-  def _get_SCSI_cmd_I2C_write(self, slaveAddr, data):
     """
-    Create an I2cWrite Command Structure to write up to 512 bytes to device
-    slaveAddr.
-
+    This Vendor Action marks an I2C Write-Read Action
     According to: 'Microchip: I2C_Over_USB_UserGuilde_50002283A.pdf' P.20
     """
+    _USB2642I2CWRITEREADSTREAM = 0x22
 
-    MAXLEN = 512
-    count = min(len(data), MAXLEN)
-    dataArray = (ctypes.c_uint8 * MAXLEN)()
-    dataArray[:count] = data[:count]
+    class _USB2642I2cWriteStruct(ctypes.Structure):
+        """I2C-Write Data Structure for up to 512 Bytes of Data
 
-    slaveWriteAddr = (slaveAddr*2)&0xFF
+        According to: 'Microchip: I2C_Over_USB_UserGuilde_50002283A.pdf' P.20
+        """
 
-    cmd = self._USB2642I2cWriteStruct(
-      ScsiVendorCommand = self._USB2642SCSIOPCODE,
-      ScsiVendorActionWriteI2C = self._USB2642I2CWRITESTREAM,
-      I2cSlaveAddress = slaveWriteAddr,
-      I2cUnused = 0x00,
-      I2cDataPhaseLenHigh = (count>>8)&0xFF,
-      I2cDataPhaseLenLow  = count&0xFF,
-      I2cCommandPhaseLen = 0x00,
-      I2cCommandPayload = (ctypes.c_uint8*9)())
+        _fields_ = [
+            ("ScsiVendorCommand", ctypes.c_uint8),
+            ("ScsiVendorActionWriteI2C", ctypes.c_uint8),
+            ("I2cSlaveAddress", ctypes.c_uint8),
+            ("I2cUnused", ctypes.c_uint8),
+            ("I2cDataPhaseLenHigh", ctypes.c_uint8),
+            ("I2cDataPhaseLenLow", ctypes.c_uint8),
+            ("I2cCommandPhaseLen", ctypes.c_uint8),
+            ("I2cCommandPayload", ctypes.c_uint8 * 9),
+        ]
 
-    return cmd, dataArray
+    assert ctypes.sizeof(_USB2642I2cWriteStruct) == 16
 
-  def _get_SCSI_cmd_I2C_write_read(self, slaveAddr, writeData, readLength):
-    """
-    Create an I2cWriteRead Command Structure to write up to 9 bytes to device
-    slaveAddr and then read back up to 512 bytes of data.
+    class _USB2642I2cReadStruct(ctypes.Structure):
+        """
+        I2C-Read Data Structure for up to 512 Bytes of Data.
 
-    According to: 'Microchip: I2C_Over_USB_UserGuilde_50002283A.pdf' P.20
-    """
+        According to: 'Microchip: I2C_Over_USB_UserGuilde_50002283A.pdf' P.20
+        """
 
-    MAXLEN = 512
-    readCount = min(readLength, MAXLEN)
-    readDataArray = (ctypes.c_uint8 * MAXLEN)()
+        _fields_ = [
+            ("ScsiVendorCommand", ctypes.c_uint8),
+            ("ScsiVendorActionWriteReadI2C", ctypes.c_uint8),
+            ("I2cWriteSlaveAddress", ctypes.c_uint8),
+            ("I2cReadSlaveAddress", ctypes.c_uint8),
+            ("I2cReadPhaseLenHigh", ctypes.c_uint8),
+            ("I2cReadPhaseLenLow", ctypes.c_uint8),
+            ("I2cWritePhaseLen", ctypes.c_uint8),
+            ("I2cWritePayload", ctypes.c_uint8 * 9),
+        ]
 
-    MAXLEN = 9
-    writeCount = min(len(writeData), MAXLEN)
-    writeDataArray = (ctypes.c_uint8 * MAXLEN)()
-    writeDataArray[:writeCount] = writeData[:writeCount]
+    assert ctypes.sizeof(_USB2642I2cReadStruct) == 16
 
-    slaveWriteAddr = (slaveAddr*2)&0xFF
-    slaveReadAddr = slaveWriteAddr + 1
+    def _get_SCSI_cmd_I2C_write(self, slaveAddr, data):
+        """
+        Create an I2cWrite Command Structure to write up to 512 bytes to device
+        slaveAddr.
 
-    cmd = self._USB2642I2cReadStruct(
-      ScsiVendorCommand = self._USB2642SCSIOPCODE,
-      ScsiVendorActionWriteReadI2C = self._USB2642I2CWRITEREADSTREAM,
-      I2cWriteSlaveAddress = slaveWriteAddr,
-      I2cReadSlaveAddress = slaveReadAddr,
-      I2cReadPhaseLenHigh = (readCount>>8)&0xFF,
-      I2cReadPhaseLenLow  = readCount&0xFF,
-      I2cWritePhaseLen = writeCount,
-      I2cCommandPayload = writeDataArray)
+        According to: 'Microchip: I2C_Over_USB_UserGuilde_50002283A.pdf' P.20
+        """
+        MAXLEN = 512
+        count = min(len(data), MAXLEN)
+        dataArray = (ctypes.c_uint8 * MAXLEN)()
+        dataArray[:count] = data[:count]
 
-    return cmd, readDataArray
+        slaveWriteAddr = (slaveAddr * 2) & 0xFF
 
+        cmd = self._USB2642I2cWriteStruct(
+            ScsiVendorCommand=self._USB2642SCSIOPCODE,
+            ScsiVendorActionWriteI2C=self._USB2642I2CWRITESTREAM,
+            I2cSlaveAddress=slaveWriteAddr,
+            I2cUnused=0x00,
+            I2cDataPhaseLenHigh=(count >> 8) & 0xFF,
+            I2cDataPhaseLenLow=count & 0xFF,
+            I2cCommandPhaseLen=0x00,
+            I2cCommandPayload=(ctypes.c_uint8 * 9)(),
+        )
 
-  def _get_SGIO(self, command, Sg_Dxfer, databuffer):
-    """Fill the SG_IO ioctl() -structure with sane defaults for the given
-    command.
-    The command will create a 64-byte sense-buffer for returned status.
+        return cmd, dataArray
 
-    Arguments:
-    command -- SCSI-Command to use. ctypes.c_uint8
-    Sg_Dxfer -- _SG_DXFER_* to set the direction of the SCSI transfer.
-    databuffer -- 512 bytes buffer of the block to read or write.
-    """
-    sense = ctypes.c_buffer(64)
+    def _get_SCSI_cmd_I2C_write_read(self, slaveAddr, writeData, readLength):
+        """
+        Create an I2cWriteRead Command Structure to write up to 9 bytes to device
+        slaveAddr and then read back up to 512 bytes of data.
 
-    sgio = self._SgioHdrStruct(
-                  # "S" for SCSI
-                  interface_id=ord('S'),
-                  # SG_DXFER_*
-                  dxfer_direction=Sg_Dxfer,
-                  # length of whatever we put into cmd
-                  cmd_len=ctypes.sizeof(command),
-                  # length of sense buffer
-                  mx_sb_len=ctypes.sizeof(sense), iovec_count=0,
-                  # data transfer length
-                  dxfer_len=ctypes.sizeof(databuffer),
-                  # pointer to data transfer buffer
-                  dxferp=ctypes.cast(databuffer, ctypes.c_void_p),
-                  # command to perform
-                  cmdp=ctypes.cast(ctypes.addressof(command), ctypes.c_void_p),
-                  # sense buffer memory
-                  sbp=ctypes.cast(sense, ctypes.c_void_p),
-                  # a timeout for this command in ms
-                  timeout=3000,
-                  # SG_FLAG_*, normally 0
-                  flags=0,
-                  # unused
-                  pack_id=0,
-                  # unused
-                  usr_ptr=None,
-                  #output: SCSI-status
-                  status=0,
-                  #output: shifted, maskes SCSI-stauts
-                  masked_status=0,
-                  #output: optional: message level data
-                  msg_status=0,
-                  #output: byte actually written to sbp
-                  sb_len_wr=0,
-                  # output: errors from host adapter
-                  host_status=0,
-                  #output: errors from software driver
-                  driver_status=0,
-                  # output: result_len: actually transferred data
-                  resid=0,
-                  #output: time for the command in ms
-                  duration=0,
-                  # output: auxiliary information (?)
-                  info=0)
+        According to: 'Microchip: I2C_Over_USB_UserGuilde_50002283A.pdf' P.20
+        """
+        MAXLEN = 512
+        readCount = min(readLength, MAXLEN)
+        readDataArray = (ctypes.c_uint8 * MAXLEN)()
 
-    return sgio, sense
+        MAXLEN = 9
+        writeCount = min(len(writeData), MAXLEN)
+        writeDataArray = (ctypes.c_uint8 * MAXLEN)()
+        writeDataArray[:writeCount] = writeData[:writeCount]
 
+        slaveWriteAddr = (slaveAddr * 2) & 0xFF
+        slaveReadAddr = slaveWriteAddr + 1
 
-  def _call_IOCTL(self, command, sg_dxfer, databuffer):
-    """
-    Call the ioctl()
+        cmd = self._USB2642I2cReadStruct(
+            ScsiVendorCommand=self._USB2642SCSIOPCODE,
+            ScsiVendorActionWriteReadI2C=self._USB2642I2CWRITEREADSTREAM,
+            I2cWriteSlaveAddress=slaveWriteAddr,
+            I2cReadSlaveAddress=slaveReadAddr,
+            I2cReadPhaseLenHigh=(readCount >> 8) & 0xFF,
+            I2cReadPhaseLenLow=readCount & 0xFF,
+            I2cWritePhaseLen=writeCount,
+            I2cCommandPayload=writeDataArray,
+        )
 
-    This function will create the struct to call the ioctl() and handle return
-    codes.
+        return cmd, readDataArray
 
-    Arguments:
-    command -- SCSI Command payload to send. 16-Byte buffer containing the SCSI
-               command parameters.
-    sg_dxfer -- _SG_DXFER_*: Direction of the SCSI transfer
-    databuffer -- 512 byte long buffer to be written oder read
-    """
-    sgio, sense = self._get_SGIO(command, sg_dxfer, databuffer)
-#    print("SGIO:")
-#    print(self.to_pretty_hex(sgio))
+    def _get_SGIO(self, command, Sg_Dxfer, databuffer):
+        """Fill the SG_IO ioctl() -structure with sane defaults for the given
+        command.
+        The command will create a 64-byte sense-buffer for returned status.
 
-    with open(self.sg, 'r+b', buffering=0) as fh:
-      rc =  fcntl.ioctl(fh, self._SG_IO, sgio)
-      if rc != 0:
-        raise IoctlFailed("SG_IO ioctl() failed with non-zero exit-code {}"\
-                          .format(rc))
-    return databuffer, sense, sgio
+        Arguments:
+        command -- SCSI-Command to use. ctypes.c_uint8
+        Sg_Dxfer -- _SG_DXFER_* to set the direction of the SCSI transfer.
+        databuffer -- 512 bytes buffer of the block to read or write.
+        """
+        sense = ctypes.c_buffer(64)
 
+        sgio = self._SgioHdrStruct(
+            # "S" for SCSI
+            interface_id=ord("S"),
+            # SG_DXFER_*
+            dxfer_direction=Sg_Dxfer,
+            # length of whatever we put into cmd
+            cmd_len=ctypes.sizeof(command),
+            # length of sense buffer
+            mx_sb_len=ctypes.sizeof(sense),
+            iovec_count=0,
+            # data transfer length
+            dxfer_len=ctypes.sizeof(databuffer),
+            # pointer to data transfer buffer
+            dxferp=ctypes.cast(databuffer, ctypes.c_void_p),
+            # command to perform
+            cmdp=ctypes.cast(ctypes.addressof(command), ctypes.c_void_p),
+            # sense buffer memory
+            sbp=ctypes.cast(sense, ctypes.c_void_p),
+            # a timeout for this command in ms
+            timeout=3000,
+            # SG_FLAG_*, normally 0
+            flags=0,
+            # unused
+            pack_id=0,
+            # unused
+            usr_ptr=None,
+            # output: SCSI-status
+            status=0,
+            # output: shifted, maskes SCSI-stauts
+            masked_status=0,
+            # output: optional: message level data
+            msg_status=0,
+            # output: byte actually written to sbp
+            sb_len_wr=0,
+            # output: errors from host adapter
+            host_status=0,
+            # output: errors from software driver
+            driver_status=0,
+            # output: result_len: actually transferred data
+            resid=0,
+            # output: time for the command in ms
+            duration=0,
+            # output: auxiliary information (?)
+            info=0,
+        )
 
-  def write_config(self, data):
-    """
-    Writes the eeprom contents from data into the config EEPROM on the auxiliary
-    I2C bus.
+        return sgio, sense
 
-    This is done using reverse-engineered commands send by the Microchip
-    Windows-Demo-Tool.
+    def _call_IOCTL(self, command, sg_dxfer, databuffer):
+        """
+        Call the ioctl()
 
-    Arguments:
-    data -- EEPROM blob to write as ctype.buffer. Length 384 Bytes as described
-            in the USB2642 Datasheet.
-    """
+        This function will create the struct to call the ioctl() and handle return
+        codes.
 
-    # SCSI Command was found on the USB-Bus.
-    # Since most of the bytes are unknown this is used as plain magic.
-    scsiCommand = list_to_uint8_array([0xCF, 0x54, 0x04, 0x00, 0x00, 0x00, 0x00,\
-                                       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,\
-                                       0x00, 0x00, 0x00], 16)
+        Arguments:
+        command -- SCSI Command payload to send. 16-Byte buffer containing the SCSI
+                   command parameters.
+        sg_dxfer -- _SG_DXFER_*: Direction of the SCSI transfer
+        databuffer -- 512 byte long buffer to be written oder read
+        """
+        sgio, sense = self._get_SGIO(command, sg_dxfer, databuffer)
+        #    print("SGIO:")
+        #    print(self.to_pretty_hex(sgio))
 
-    # Data in the captured USB-transfer was suffixed with some random data.
-    # Experiments showed that 0x00 works fine too.
-    # Since the buffer is zero-ed when initialized the suffix could be removed.
-    data_suffix = list_to_uint8_array([0x00], 127)
+        with open(self.sg, "r+b", buffering=0) as fh:
+            rc = fcntl.ioctl(fh, self._SG_IO, sgio)
+            if rc != 0:
+                raise IoctlFailed("SG_IO ioctl() failed with non-zero exit-code {}".format(rc))
+        return databuffer, sense, sgio
 
-    # Copying prefix, data and suffix to the SCSI command data-section
-    payload = (ctypes.c_uint8*512)()
-    payload[:ctypes.sizeof(data)] = data
-    payload[ctypes.sizeof(data):ctypes.sizeof(data) + ctypes.sizeof(data_suffix)] = data_suffix
+    def write_config(self, data):
+        """
+        Writes the eeprom contents from data into the config EEPROM on the auxiliary
+        I2C bus.
 
-    # Perform the actual SCSI transfer
-    self._call_IOCTL(scsiCommand, self._SG_DXFER_TO_DEV, payload)
+        This is done using reverse-engineered commands send by the Microchip
+        Windows-Demo-Tool.
 
+        Arguments:
+        data -- EEPROM blob to write as ctype.buffer. Length 384 Bytes as described
+                in the USB2642 Datasheet.
+        """
 
-  def write_read_to(self, i2cAddr, writeData, readLength):
-    """
-    Tries to write data to an I2C-Device and afterwards read data from that
-    device.
+        # SCSI Command was found on the USB-Bus.
+        # Since most of the bytes are unknown this is used as plain magic.
+        scsiCommand = list_to_uint8_array(
+            [0xCF, 0x54, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], 16
+        )
 
-    This function will perform am I2C-Transaction like the following:
+        # Data in the captured USB-transfer was suffixed with some random data.
+        # Experiments showed that 0x00 works fine too.
+        # Since the buffer is zero-ed when initialized the suffix could be removed.
+        data_suffix = list_to_uint8_array([0x00], 127)
 
-    * I2C-Start
-    * I2C-Slave address with R/W = W (0)
-    * writeData[0]
-    * writeData[1]
-    * ...
-    * I2C-Repeated Start
-    * I2C-Slave address wit R/W = R (1)
-    * readData[0]
-    * readData[1]
-    * ...
-    * I2C-Stop
+        # Copying prefix, data and suffix to the SCSI command data-section
+        payload = (ctypes.c_uint8 * 512)()
+        payload[: ctypes.sizeof(data)] = data
+        payload[ctypes.sizeof(data) : ctypes.sizeof(data) + ctypes.sizeof(data_suffix)] = data_suffix
 
-    This transaction can (for example) be used to set the address-pointer inside
-    an EEPROM and read data from it.
+        # Perform the actual SCSI transfer
+        self._call_IOCTL(scsiCommand, self._SG_DXFER_TO_DEV, payload)
 
-    Arguments:
-    i2cAddr -- 7-Bit I2C Slave address (as used by Linux). Will be shifted 1 Bit
-               to the left before adding the R/W-bit.
-    writeData -- iterable of bytes to write in the first phase
-    readLengh -- number of bytes (0..512) to read in the second phase
-    """
-    scsiCommand, data = self._get_SCSI_cmd_I2C_write_read(i2cAddr, writeData,\
-                                                          readLength)
-    # TODO: Add error handling if length of read or write do not match
-    #       requirements
+    def write_read_to(self, i2cAddr, writeData, readLength):
+        """
+        Tries to write data to an I2C-Device and afterwards read data from that
+        device.
 
-#    print("I2C-Command:")
-#    print(self.to_pretty_hex(scsiCommand))
-#    print("I2C-Payload:")
-#    print(self.to_pretty_hex(data))
-    data, sense, sgio = self._call_IOCTL(scsiCommand, self._SG_DXFER_FROM_DEV,\
-                                         data)
+        This function will perform am I2C-Transaction like the following:
 
-    if sgio.status != 0:
-      raise I2cTransactionFailed(\
-            "SCSI-Transaction ended with status {}. I2C-Transaction has probably failed.".\
-                                 format(sgio.status))
+        * I2C-Start
+        * I2C-Slave address with R/W = W (0)
+        * writeData[0]
+        * writeData[1]
+        * ...
+        * I2C-Repeated Start
+        * I2C-Slave address wit R/W = R (1)
+        * readData[0]
+        * readData[1]
+        * ...
+        * I2C-Stop
 
-    return list(data[:readLength])
+        This transaction can (for example) be used to set the address-pointer inside
+        an EEPROM and read data from it.
 
-  def write_to(self, i2cAddr, data):
-    """
-    Tries to write data to an I2C-Device.
+        Arguments:
+        i2cAddr -- 7-Bit I2C Slave address (as used by Linux). Will be shifted 1 Bit
+                   to the left before adding the R/W-bit.
+        writeData -- iterable of bytes to write in the first phase
+        readLengh -- number of bytes (0..512) to read in the second phase
+        """
+        scsiCommand, data = self._get_SCSI_cmd_I2C_write_read(i2cAddr, writeData, readLength)
+        # TODO: Add error handling if length of read or write do not match
+        #       requirements
 
-    This function will perform am I2C-Transaction like the following:
+        #    print("I2C-Command:")
+        #    print(self.to_pretty_hex(scsiCommand))
+        #    print("I2C-Payload:")
+        #    print(self.to_pretty_hex(data))
+        data, sense, sgio = self._call_IOCTL(scsiCommand, self._SG_DXFER_FROM_DEV, data)
 
-    * I2C-Start
-    * I2C-Slave address with R/W = W (0)
-    * data[0]
-    * data[1]
-    * ...
-    * I2C-Stop
+        if sgio.status != 0:
+            raise I2cTransactionFailed(
+                "SCSI-Transaction ended with status {}. I2C-Transaction has probably failed.".format(sgio.status)
+            )
 
-    Transactions like this can (for example) be used if configuration registers
-    on a device have to be written.
+        return list(data[:readLength])
 
-    Arguments:
-    i2cAddr -- 7-Bit I2C Slave address (as used by Linux). Will be shifted 1 Bit
-               to the left before adding the R/W-bit.
-    data -- iterateable of bytes to write."""
-    scsiCommand, data = self._get_SCSI_cmd_I2C_write(i2cAddr, data)
-    # TODO: Add length checks
+    def write_to(self, i2cAddr, data):
+        """
+        Tries to write data to an I2C-Device.
 
-#    print("I2C-Command:")
-#    print(self.to_pretty_hex(scsiCommand))
-#    print("I2C-Payload:")
-#    print(self.to_pretty_hex(data))
-    data, sense, sgio = self._call_IOCTL(scsiCommand, self._SG_DXFER_TO_DEV,\
-                                         data)
+        This function will perform am I2C-Transaction like the following:
 
-    if sgio.status != 0:
-      raise I2cTransactionFailed(\
-            "SCSI-Transaction ended with status {}. I2C-Transaction has probably failed.".\
-                                 format(sgio.status))
+        * I2C-Start
+        * I2C-Slave address with R/W = W (0)
+        * data[0]
+        * data[1]
+        * ...
+        * I2C-Stop
+
+        Transactions like this can (for example) be used if configuration registers
+        on a device have to be written.
+
+        Arguments:
+        i2cAddr -- 7-Bit I2C Slave address (as used by Linux). Will be shifted 1 Bit
+                   to the left before adding the R/W-bit.
+        data -- iterateable of bytes to write."""
+        scsiCommand, data = self._get_SCSI_cmd_I2C_write(i2cAddr, data)
+        # TODO: Add length checks
+
+        #    print("I2C-Command:")
+        #    print(self.to_pretty_hex(scsiCommand))
+        #    print("I2C-Payload:")
+        #    print(self.to_pretty_hex(data))
+        data, sense, sgio = self._call_IOCTL(scsiCommand, self._SG_DXFER_TO_DEV, data)
+
+        if sgio.status != 0:
+            raise I2cTransactionFailed(
+                "SCSI-Transaction ended with status {}. I2C-Transaction has probably failed.".format(sgio.status)
+            )

--- a/usbsdmux/usb2642i2c.py
+++ b/usbsdmux/usb2642i2c.py
@@ -20,13 +20,10 @@
 
 import ctypes
 import fcntl
-from .ctypehelper import (
-    string_to_microchip_unicode_uint8_array,
-    string_to_uint8_array,
-    list_to_uint8_array,
-    to_pretty_hex,
-)
 
+from .ctypehelper import (
+    list_to_uint8_array,
+)
 
 """
 This modules provides an interface to use the auxiliary and configuration
@@ -370,7 +367,7 @@ class Usb2642I2C(object):
         # Copying prefix, data and suffix to the SCSI command data-section
         payload = (ctypes.c_uint8 * 512)()
         payload[: ctypes.sizeof(data)] = data
-        payload[ctypes.sizeof(data) : ctypes.sizeof(data) + ctypes.sizeof(data_suffix)] = data_suffix
+        payload[ctypes.sizeof(data) : ctypes.sizeof(data) + ctypes.sizeof(data_suffix)] = data_suffix  # noqa: E203
 
         # Perform the actual SCSI transfer
         self._call_IOCTL(scsiCommand, self._SG_DXFER_TO_DEV, payload)

--- a/usbsdmux/usbsdmux.py
+++ b/usbsdmux/usbsdmux.py
@@ -19,6 +19,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 import time
+
 from .pca9536 import Pca9536
 
 

--- a/usbsdmux/usbsdmux.py
+++ b/usbsdmux/usbsdmux.py
@@ -23,98 +23,89 @@ from .pca9536 import Pca9536
 
 
 class UsbSdMux(object):
-  """
-  Class to provide an interface for the multiplexer on an usb-sd-mux.
-  """
-
-  _DAT_enable = 0x00
-  _DAT_disable = Pca9536.gpio_0
-
-  _PWR_enable = 0x00
-  _PWR_disable = Pca9536.gpio_1
-
-  _select_DUT = Pca9536.gpio_2
-  _select_HOST = 0x00
-
-  _card_inserted = 0x00
-  _card_removed = Pca9536.gpio_3
-
-  def __init__(self, sg):
     """
-    Create a new UsbSdMux.
-
-    Arguments:
-    sg -- /dev/sg* to use
-    """
-    self._pca = Pca9536(sg)
-
-  def get_mode(self):
-    """
-    Returns currently selected mode as string
-    """
-    val = self._pca.read_register(1)[0]
-
-    # If the SD-Card is disabled we do not need to check for the selected mode.
-    # PWR_disable and DAT_disable are always switched at the same time.
-    # Let's assume it is sufficient to check one of both.
-    if val & self._PWR_disable:
-      return "off"
-
-    if val & self._select_DUT:
-       return "dut"
-    return "host"
-
-  def mode_disconnect(self, wait=True):
-    """
-    Will disconnect the Micro-SD Card from both host and DUT.
-
-    Arugments:
-    wait -- Command will block for some time until the voltage-supply of
-    the sd-card is known to be close to zero
+    Class to provide an interface for the multiplexer on an usb-sd-mux.
     """
 
-    # Set the output registers to known values and activate them afterwards
-    self._pca.output_values(self._DAT_disable | self._PWR_disable |
-                            self._select_HOST | self._card_removed)
-    self._pca.set_pin_to_output(Pca9536.gpio_0 | Pca9536.gpio_1 |
-                                Pca9536.gpio_2 | Pca9536.gpio_3)
+    _DAT_enable = 0x00
+    _DAT_disable = Pca9536.gpio_0
 
-    if wait:
-        time.sleep(1)
+    _PWR_enable = 0x00
+    _PWR_disable = Pca9536.gpio_1
 
-  def mode_DUT(self, wait=True):
-    """
-    Switches the MicroSD-Card to the DUT.
+    _select_DUT = Pca9536.gpio_2
+    _select_HOST = 0x00
 
-    This Command will issue a disconnect first to make sure the the SD-card
-    has been properly disconnected from both sides and it's supply was off.
-    """
+    _card_inserted = 0x00
+    _card_removed = Pca9536.gpio_3
 
-    self.mode_disconnect(wait)
+    def __init__(self, sg):
+        """
+        Create a new UsbSdMux.
 
-    # switch selection to DUT first to prevent glitches on power and
-    # data-lines
-    self._pca.output_values(self._DAT_disable | self._PWR_disable |
-                            self._select_DUT | self._card_removed)
+        Arguments:
+        sg -- /dev/sg* to use
+        """
+        self._pca = Pca9536(sg)
 
-    # now connect data and power
-    self._pca.output_values(self._DAT_enable | self._PWR_enable |
-                            self._select_DUT | self._card_removed)
+    def get_mode(self):
+        """
+        Returns currently selected mode as string
+        """
+        val = self._pca.read_register(1)[0]
 
-  def mode_host(self, wait=True):
-    """
-    Switches the MicroSD-Card to the Host.
+        # If the SD-Card is disabled we do not need to check for the selected mode.
+        # PWR_disable and DAT_disable are always switched at the same time.
+        # Let's assume it is sufficient to check one of both.
+        if val & self._PWR_disable:
+            return "off"
 
-    This Command will issue a disconnect first to make sure the the SD-card
-    has been properly disconnected from both sides and it's supply was off.
-    """
+        if val & self._select_DUT:
+            return "dut"
+        return "host"
 
-    self.mode_disconnect(wait)
+    def mode_disconnect(self, wait=True):
+        """
+        Will disconnect the Micro-SD Card from both host and DUT.
 
-    # the disconnect-command has already switched the card to the host.
-    # Thus we don't need to worry about glitches anymore.
+        Arugments:
+        wait -- Command will block for some time until the voltage-supply of
+        the sd-card is known to be close to zero
+        """
+        # Set the output registers to known values and activate them afterwards
+        self._pca.output_values(self._DAT_disable | self._PWR_disable | self._select_HOST | self._card_removed)
+        self._pca.set_pin_to_output(Pca9536.gpio_0 | Pca9536.gpio_1 | Pca9536.gpio_2 | Pca9536.gpio_3)
 
-    # now connect data and power
-    self._pca.output_values(self._DAT_enable | self._PWR_enable |
-                            self._select_HOST | self._card_inserted)
+        if wait:
+            time.sleep(1)
 
+    def mode_DUT(self, wait=True):
+        """
+        Switches the MicroSD-Card to the DUT.
+
+        This Command will issue a disconnect first to make sure the the SD-card
+        has been properly disconnected from both sides and it's supply was off.
+        """
+        self.mode_disconnect(wait)
+
+        # switch selection to DUT first to prevent glitches on power and
+        # data-lines
+        self._pca.output_values(self._DAT_disable | self._PWR_disable | self._select_DUT | self._card_removed)
+
+        # now connect data and power
+        self._pca.output_values(self._DAT_enable | self._PWR_enable | self._select_DUT | self._card_removed)
+
+    def mode_host(self, wait=True):
+        """
+        Switches the MicroSD-Card to the Host.
+
+        This Command will issue a disconnect first to make sure the the SD-card
+        has been properly disconnected from both sides and it's supply was off.
+        """
+        self.mode_disconnect(wait)
+
+        # the disconnect-command has already switched the card to the host.
+        # Thus we don't need to worry about glitches anymore.
+
+        # now connect data and power
+        self._pca.output_values(self._DAT_enable | self._PWR_enable | self._select_HOST | self._card_inserted)


### PR DESCRIPTION
This PR adds `flake8` and `black` to this project.

We first set the tooling up for local use. Running `make qa` will run both tools and output any problems found.

Next:
* The code is reformatted using `black` and some odd whitespaces removed (while we are on it).
* Findings by `flake8` are corrected and the imports re-sorted.

Finally this PR adds Github actions to run the tools on push and in PRs.