### PR TITLE
Add support for the USB-SD-Mux FAST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 .tox/
 envs/
 .idea
+venv/

--- a/usbsdmux/i2c_gpio.py
+++ b/usbsdmux/i2c_gpio.py
@@ -114,7 +114,7 @@ class Pca9536(I2cGpio):
     """
 
     # The PCA9536 I2C slave Address in 7-Bit Format
-    _I2cAddr = 0x41
+    _I2cAddr = 0b100_0001
 
     gpio_0 = 0x01
     gpio_1 = 0x02
@@ -129,7 +129,7 @@ class Tca6408(I2cGpio):
     """
 
     # The TCA6408 I2C slave Address in 7-Bit Format
-    _I2cAddr = 0b0100_000
+    _I2cAddr = 0b010_0000
 
     gpio_0 = 0x01
     gpio_1 = 0x02

--- a/usbsdmux/i2c_gpio.py
+++ b/usbsdmux/i2c_gpio.py
@@ -19,55 +19,40 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 from .usb2642i2c import Usb2642I2C
+from abc import ABC
 
 
-class Pca9536(object):
-    """
-    Interface to control a Pca9536 that is connected to the auxiliary-I2C of a
-    Microchip USB2642.
-    """
-
-    # The PCA9536 I2C Slave Address in 7-Bit Format
-    _I2cAddr = 0x41
-
-    # Registers inside the PCA9536
+class I2cGpio(ABC):
+    # Registers inside the supported GPIO expanders
     _register_inputPort = 0x00
     _register_outputPort = 0x01
     _register_polarity = 0x02
     _register_configuration = 0x03
 
-    gpio_0 = 0x01
-    gpio_1 = 0x02
-    gpio_2 = 0x04
-    gpio_3 = 0x08
-
+    # Values for the configuration register
     _direction_output = 0
     _direction_input = 1
 
     def __init__(self, sg):
         """
-        Create a new Pca9536-controller.
-
         Arguments:
         sg -- /dev/sg* to use.
         """
-        self.sg = sg
-
         self._usb = Usb2642I2C(sg)
 
-        # After POR all Pins are Inputs. This value will from now on mirror the
-        # value of die _register_configuration
+        # After POR all Pins are Inputs.
+        # This value mirrors the value of the GPIO configuration
         self._directionMask = 0xFF
 
     def _write_register(self, register, value):
         """
-        Writes a register on the Pca9536 with a given value.
+        Writes a register on the GPIO-expander with a given value.
         """
         self._usb.write_to(self._I2cAddr, [register, value])
 
     def read_register(self, addr, len=1):
         """
-        Returns a register of the Pca9536.
+        Returns a register of the GPIO-expander.
         """
         return self._usb.write_read_to(self._I2cAddr, [addr], len)
 
@@ -76,7 +61,7 @@ class Pca9536(object):
         Sets the corresponding pins as outputs.
 
         Arguments:
-        pins -- Combination of Pca9536.gpio_*
+        pins -- Combination of I2cGpio.gpio_*
         """
         self._directionMask = self._directionMask & (~pins)
         self._write_register(self._register_configuration, self._directionMask)
@@ -86,7 +71,7 @@ class Pca9536(object):
         Sets the corresponding pins as inputs.
 
         Arguments:
-        pins -- Combination of Pca9536.gpio_*
+        pins -- Combination of I2cGpio.gpio_*
         """
         self._directionMask = self._directionMask | pins
         self._write_register(self._register_configuration, self._directionMask)
@@ -97,6 +82,21 @@ class Pca9536(object):
         Pins configured as Inputs are not affected by this.
 
         Arguments:
-        values -- Combination of Pca9536.gpio_*
+        values -- Combination of I2cGpio.gpio_*
         """
         self._write_register(self._register_outputPort, values)
+
+
+class Pca9536(I2cGpio):
+    """
+    Interface to control a Pca9536 that is connected to the auxiliary-I2C of a
+    Microchip USB2642.
+    """
+
+    # The PCA9536 I2C slave Address in 7-Bit Format
+    _I2cAddr = 0x41
+
+    gpio_0 = 0x01
+    gpio_1 = 0x02
+    gpio_2 = 0x04
+    gpio_3 = 0x08

--- a/usbsdmux/i2c_gpio.py
+++ b/usbsdmux/i2c_gpio.py
@@ -40,10 +40,6 @@ class I2cGpio(ABC):
         """
         self._usb = Usb2642I2C(sg)
 
-        # After POR all Pins are Inputs.
-        # This value mirrors the value of the GPIO configuration
-        self._directionMask = 0xFF
-
     def _write_register(self, register, value):
         """
         Writes a register on the GPIO-expander with a given value.
@@ -63,8 +59,9 @@ class I2cGpio(ABC):
         Arguments:
         pins -- Combination of I2cGpio.gpio_*
         """
-        self._directionMask = self._directionMask & (~pins)
-        self._write_register(self._register_configuration, self._directionMask)
+        direction = self.read_register(self._register_configuration)[0]
+        direction = (direction & ~pins) & 0xFF
+        self._write_register(self._register_configuration, direction)
 
     def set_pin_to_input(self, pins):
         """
@@ -73,8 +70,9 @@ class I2cGpio(ABC):
         Arguments:
         pins -- Combination of I2cGpio.gpio_*
         """
-        self._directionMask = self._directionMask | pins
-        self._write_register(self._register_configuration, self._directionMask)
+        direction = self.read_register(self._register_configuration)[0]
+        direction = direction | pins
+        self._write_register(self._register_configuration, direction)
 
     def output_values(self, values: int, bitmask: int = 0xFF):
         """

--- a/usbsdmux/i2c_gpio.py
+++ b/usbsdmux/i2c_gpio.py
@@ -100,3 +100,22 @@ class Pca9536(I2cGpio):
     gpio_1 = 0x02
     gpio_2 = 0x04
     gpio_3 = 0x08
+
+
+class Tca6408(I2cGpio):
+    """
+    Interface to control a TCA6408 that is connected to the auxiliary-I2C of a
+    Microchip USB2642.
+    """
+
+    # The TCA6408 I2C slave Address in 7-Bit Format
+    _I2cAddr = 0b0100_000
+
+    gpio_0 = 0x01
+    gpio_1 = 0x02
+    gpio_2 = 0x04
+    gpio_3 = 0x08
+    gpio_4 = 0x10
+    gpio_5 = 0x20
+    gpio_6 = 0x40
+    gpio_7 = 0x80

--- a/usbsdmux/usb2642i2c.py
+++ b/usbsdmux/usb2642i2c.py
@@ -252,7 +252,7 @@ class Usb2642I2C(object):
             I2cReadPhaseLenHigh=(readCount >> 8) & 0xFF,
             I2cReadPhaseLenLow=readCount & 0xFF,
             I2cWritePhaseLen=writeCount,
-            I2cCommandPayload=writeDataArray,
+            I2cWritePayload=writeDataArray,
         )
 
         return cmd, readDataArray

--- a/usbsdmux/usbsdmux.py
+++ b/usbsdmux/usbsdmux.py
@@ -159,6 +159,7 @@ class UsbSdMuxClassic(UsbSdMux):
 
         if val & self._select_DUT:
             return "dut"
+
         return "host"
 
     def mode_disconnect(self, wait=True):
@@ -244,6 +245,7 @@ class UsbSdMuxFast(UsbSdMux):
 
         if val & self._select_DUT:
             return "dut"
+
         return "host"
 
     def mode_disconnect(self, wait=True):

--- a/usbsdmux/usbsdmux.py
+++ b/usbsdmux/usbsdmux.py
@@ -53,7 +53,7 @@ class UsbSdMux(object):
         """
         Returns currently selected mode as string
         """
-        val = self._pca.read_register(1)[0]
+        val = self._pca.get_input_values()
 
         # If the SD-Card is disabled we do not need to check for the selected mode.
         # PWR_disable and DAT_disable are always switched at the same time.

--- a/usbsdmux/usbsdmux.py
+++ b/usbsdmux/usbsdmux.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import abc
 
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
@@ -18,16 +19,120 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
+import os
 import time
 
-from .pca9536 import Pca9536
+from .i2c_gpio import Pca9536, Tca6408
 
 
-class UsbSdMux(object):
+class UnknownUsbSdMuxRevisionException(Exception):
+    pass
+
+
+def autoselect_driver(sg):
+    """
+    Create a new UsbSdMux with the correct driver for the device at /dev/<sg>
+
+    Arguments:
+    sg -- /dev/sg* to use
+    """
+
+    base_sg = os.path.realpath(sg)
+    sg_name = os.path.basename(base_sg)
+    model_filename = f"/sys/class/scsi_generic/{sg_name}/device/model"
+    try:
+        with open(model_filename, "r") as fh:
+            model = fh.read().strip()
+        if model == "sdmux HS-SD/MMC":
+            return UsbSdMuxClassic(sg)
+        elif model == "sdFST HS-SD/MMC":
+            return UsbSdMuxFast(sg)
+        else:
+            raise UnknownUsbSdMuxRevisionException(
+                f"Could not determine type of USB-SD-Mux. Found unknown SCSI model '{model}'."
+            )
+    except FileNotFoundError as e:
+        raise UnknownUsbSdMuxRevisionException(
+            f"Could not determine type of USB-SD-Mux. Does {model_filename} exist?"
+        ) from e
+
+
+class UsbSdMux(abc.ABC):
     """
     Class to provide an interface for the multiplexer on an usb-sd-mux.
     """
 
+    @abc.abstractmethod
+    def __init__(self, sg):
+        """
+        Create a new UsbSdMux.
+
+        Arguments:
+        sg -- /dev/sg* to use
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_mode(self):
+        """
+        Returns currently selected mode as string
+        """
+        pass
+
+    @abc.abstractmethod
+    def mode_disconnect(self, wait=True):
+        """
+        Will disconnect the Micro-SD Card from both host and DUT.
+
+        Arguments:
+        wait -- Command will block for some time until the voltage-supply of
+        the sd-card is known to be close to zero
+        """
+        pass
+
+    @abc.abstractmethod
+    def mode_DUT(self, wait=True):
+        """
+        Switches the MicroSD-Card to the DUT.
+
+        This Command will issue a disconnect first to make sure the SD-card
+        has been properly disconnected from both sides and its supply was off.
+        """
+        pass
+
+    @abc.abstractmethod
+    def mode_host(self, wait=True):
+        """
+        Switches the MicroSD-Card to the Host.
+
+        This Command will issue a disconnect first to make sure the SD-card
+        has been properly disconnected from both sides and its supply was off.
+        """
+        pass
+
+    @abc.abstractmethod
+    def gpio_get(self, gpio):
+        """
+        Reads the value of gpio and returns "high" or "low"
+        """
+        pass
+
+    @abc.abstractmethod
+    def gpio_set_high(self, gpio):
+        """
+        Sets a gpio high.
+        """
+        pass
+
+    @abc.abstractmethod
+    def gpio_set_low(self, gpio):
+        """
+        Sets a gpio low.
+        """
+        pass
+
+
+class UsbSdMuxClassic(UsbSdMux):
     _DAT_enable = 0x00
     _DAT_disable = Pca9536.gpio_0
 
@@ -41,21 +146,12 @@ class UsbSdMux(object):
     _card_removed = Pca9536.gpio_3
 
     def __init__(self, sg):
-        """
-        Create a new UsbSdMux.
-
-        Arguments:
-        sg -- /dev/sg* to use
-        """
         self._pca = Pca9536(sg)
 
     def get_mode(self):
-        """
-        Returns currently selected mode as string
-        """
         val = self._pca.get_input_values()
 
-        # If the SD-Card is disabled we do not need to check for the selected mode.
+        # If the SD-Card is disabled, we do not need to check for the selected mode.
         # PWR_disable and DAT_disable are always switched at the same time.
         # Let's assume it is sufficient to check one of both.
         if val & self._PWR_disable:
@@ -66,14 +162,7 @@ class UsbSdMux(object):
         return "host"
 
     def mode_disconnect(self, wait=True):
-        """
-        Will disconnect the Micro-SD Card from both host and DUT.
-
-        Arugments:
-        wait -- Command will block for some time until the voltage-supply of
-        the sd-card is known to be close to zero
-        """
-        # Set the output registers to known values and activate them afterwards
+        # Set the output registers to known values and activate them afterward
         self._pca.output_values(self._DAT_disable | self._PWR_disable | self._select_HOST | self._card_removed)
         self._pca.set_pin_to_output(Pca9536.gpio_0 | Pca9536.gpio_1 | Pca9536.gpio_2 | Pca9536.gpio_3)
 
@@ -81,12 +170,6 @@ class UsbSdMux(object):
             time.sleep(1)
 
     def mode_DUT(self, wait=True):
-        """
-        Switches the MicroSD-Card to the DUT.
-
-        This Command will issue a disconnect first to make sure the the SD-card
-        has been properly disconnected from both sides and it's supply was off.
-        """
         self.mode_disconnect(wait)
 
         # switch selection to DUT first to prevent glitches on power and
@@ -97,16 +180,131 @@ class UsbSdMux(object):
         self._pca.output_values(self._DAT_enable | self._PWR_enable | self._select_DUT | self._card_removed)
 
     def mode_host(self, wait=True):
-        """
-        Switches the MicroSD-Card to the Host.
-
-        This Command will issue a disconnect first to make sure the the SD-card
-        has been properly disconnected from both sides and it's supply was off.
-        """
         self.mode_disconnect(wait)
 
-        # the disconnect-command has already switched the card to the host.
-        # Thus we don't need to worry about glitches anymore.
+        # The disconnect-command has already switched the card to the host.
+        # Thus, we don't need to worry about glitches anymore.
 
         # now connect data and power
         self._pca.output_values(self._DAT_enable | self._PWR_enable | self._select_HOST | self._card_inserted)
+
+    def gpio_get(self, gpio):
+        raise NotImplementedError()
+
+    def gpio_set_high(self, gpio):
+        raise NotImplementedError()
+
+    def gpio_set_low(self, gpio):
+        raise NotImplementedError()
+
+
+class UsbSdMuxFast(UsbSdMux):
+    _DAT_enable = 0x00
+    _DAT_disable = Tca6408.gpio_2
+
+    _PWR_enable = 0x00
+    _PWR_disable = Tca6408.gpio_1
+
+    _select_DUT = Tca6408.gpio_0
+    _select_HOST = 0x00
+
+    _card_inserted = 0x00
+    _card_removed = Tca6408.gpio_3
+
+    gpio0 = Tca6408.gpio_4
+    gpio1 = Tca6408.gpio_5
+
+    def __init__(self, sg):
+        self._tca = Tca6408(sg)
+        self._assure_default_state()
+
+    def _assure_default_state(self):
+        # If the USB-SD-Mux has just been powered on, its default ("DUT") is defined by pull-resistors.
+        # If we now do a "read-modify-write" without taking into account the external default, we will
+        # lose this state.
+        # So let's check if the GPIO-expander is in Power-On-Reset defaults.
+        # If so, write the same state to the device - but with driven outputs.
+
+        if self._tca.get_gpio_config() == 0xFF:
+            # If all pins are still set to "input" we are in the default state.
+            # Let's set an output value that matches this configuration and set the relevant pins to output.
+            self._tca.output_values(self._DAT_enable | self._PWR_enable | self._select_DUT | self._card_removed)
+            self._tca.set_pin_to_output(
+                Tca6408.gpio_0 | Tca6408.gpio_1 | Tca6408.gpio_2 | Tca6408.gpio_3 | Tca6408.gpio_4 | Tca6408.gpio_5
+            )
+
+    def get_mode(self):
+        val = self._tca.get_input_values()
+
+        # If the SD-Card is disabled, we do not need to check for the selected mode.
+        # PWR_disable and DAT_disable are always switched at the same time.
+        # Let's assume it is sufficient to check one of both.
+        if val & self._PWR_disable:
+            return "off"
+
+        if val & self._select_DUT:
+            return "dut"
+        return "host"
+
+    def mode_disconnect(self, wait=True):
+        self._tca.output_values(
+            values=self._DAT_disable | self._PWR_disable | self._select_HOST | self._card_removed,
+            bitmask=self._tca.gpio_0 | self._tca.gpio_1 | self._tca.gpio_2 | self._tca.gpio_3,
+        )
+
+        if wait:
+            time.sleep(1)
+
+    def mode_DUT(self, wait=True):
+        self.mode_disconnect(wait)
+
+        # switch selection to DUT first to prevent glitches on power and
+        # data-lines
+        self._tca.output_values(
+            values=self._DAT_disable | self._PWR_disable | self._select_DUT | self._card_removed,
+            bitmask=self._tca.gpio_0 | self._tca.gpio_1 | self._tca.gpio_2 | self._tca.gpio_3,
+        )
+
+        # now connect data and power
+        self._tca.output_values(
+            values=self._DAT_enable | self._PWR_enable | self._select_DUT | self._card_removed,
+            bitmask=self._tca.gpio_0 | self._tca.gpio_1 | self._tca.gpio_2 | self._tca.gpio_3,
+        )
+
+    def mode_host(self, wait=True):
+        self.mode_disconnect(wait)
+
+        # The disconnect-command has already switched the card to the host.
+        # Thus, we don't need to worry about glitches anymore.
+
+        # now connect data and power
+        self._tca.output_values(
+            values=self._DAT_enable | self._PWR_enable | self._select_HOST | self._card_inserted,
+            bitmask=self._tca.gpio_0 | self._tca.gpio_1 | self._tca.gpio_2 | self._tca.gpio_3,
+        )
+
+    @staticmethod
+    def _map_gpio(gpio):
+        if gpio == 0:
+            return UsbSdMuxFast.gpio0
+        elif gpio == 1:
+            return UsbSdMuxFast.gpio1
+        raise ValueError("Unknown GPIO")
+
+    def gpio_get(self, gpio):
+        """
+        Reads the value of gpio and returns "high" or "low"
+        """
+        gpio = UsbSdMuxFast._map_gpio(gpio)
+        val = self._tca.get_input_values()
+        if val & gpio:
+            return "low"
+        return "high"
+
+    def gpio_set_high(self, gpio):
+        gpio = UsbSdMuxFast._map_gpio(gpio)
+        self._tca.output_values(0x0, gpio)
+
+    def gpio_set_low(self, gpio):
+        gpio = UsbSdMuxFast._map_gpio(gpio)
+        self._tca.output_values(gpio, gpio)


### PR DESCRIPTION
The USB-SD-Mux FAST is a next generation prototype of the USB-SD-Mux.
This new generation contains  a new *I2C GPIO expander* and also provides two external open-drain outputs.

This PR adds support for this new hardware to this tooling.

For co-existence of old and new USB-SD-Muxes this PR also adds support to automatically detect the version of the USB-SD-Mux. This feature will also help to catch cases where the tooling is accidentally used on a another SCSI device (e.g. a hard drive or generic card reader).