### PR TITLE
CI: add job that checks README.rst against usbsdmux -h output

### DIFF
--- a/.github/workflows/readme.py
+++ b/.github/workflows/readme.py
@@ -1,0 +1,21 @@
+import subprocess
+import sys
+
+usbsdmux_help = subprocess.run(["usbsdmux", "-h"], capture_output=True).stdout
+usbsdmux_help = usbsdmux_help.decode("utf-8")
+
+# Convert to the indentation we have in the README.rst
+usbsdmux_help = "$ usbsdmux -h\n" + usbsdmux_help
+usbsdmux_help = "\n".join(("    " + line) if line.strip() != "" else "" for line in usbsdmux_help.split("\n"))
+
+readme_help = open("README.rst").read()
+
+if usbsdmux_help not in readme_help:
+    print("The help text in the README.rst is not up to date.")
+    print("Update the README.rst with the following content:")
+    print("")
+    print(".. code-block:: text")
+    print("")
+    print(usbsdmux_help)
+
+    sys.exit(1)

--- a/.github/workflows/readme.yml
+++ b/.github/workflows/readme.yml
@@ -1,0 +1,17 @@
+name: readme
+
+on: [push, pull_request]
+
+jobs:
+  readme-help:
+    name: usbsdmux -h is up to date
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies and usbsdmux tool
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install .
+      - name: Run the check
+        run: |
+          python3 .github/workflows/readme.py

--- a/README.rst
+++ b/README.rst
@@ -65,21 +65,24 @@ command invocations:
 
 .. code-block:: text
 
-   $ usbsdmux -h
-   usage: usbsdmux [-h] SG {get,dut,client,host,off}
+    $ usbsdmux -h
+    usage: usbsdmux [-h] [--json] SG {get,dut,client,host,off,gpio,info} ...
 
-   positional arguments:
-     SG                    /dev/sg* to use
-     {get,dut,client,host,off}
-			   Action:
-			   get - return selected mode
-			   dut - set to dut mode
-			   client - set to dut mode (alias for dut)
-			   host - set to host mode
-			   off - set to off mode
+    positional arguments:
+      SG                    /dev/sg* to use
+      {get,dut,client,host,off,gpio,info}
+                            Supply one of the following commands to interact with the device
+        get                 Read the current state of the USB-SD-Mux
+        dut                 Switch to the DUT
+        client              Switch to the DUT
+        host                Switch to the host
+        off                 Disconnect from host and DUT
+        gpio                Manipulate a GPIO (open drain output only)
+        info                Show information about the SD card
 
-   optional arguments:
-     -h, --help            show this help message and exit
+    options:
+      -h, --help            show this help message and exit
+      --json                Format output as json. Useful for scripting.
 
 Using as root
 -------------


### PR DESCRIPTION
The `usbsdmux -h` output in the `README.rst` has become out of date with the actual output of the tool.
This can be quite confusing, as it makes it unclear which features the tool has.

Update the `README.rst` content and make sure it stays up to date via a CI job.

See [this job run](https://github.com/hnez/usbsdmux/actions/runs/7285610907/job/19852823485#step:4:29) for an example of the job failing.