### PR TITLE
add test that checks README.rst against usbsdmux -h output

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install python dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --upgrade pytest
+          python -m pip install --upgrade pytest pytest-mock
       - name: Run pytest
         run: |
           python -m pytest -vv

--- a/README.rst
+++ b/README.rst
@@ -66,20 +66,23 @@ command invocations:
 .. code-block:: text
 
    $ usbsdmux -h
-   usage: usbsdmux [-h] SG {get,dut,client,host,off}
+   usage: usbsdmux [-h] [--json] SG {get,dut,client,host,off,gpio,info} ...
 
    positional arguments:
      SG                    /dev/sg* to use
-     {get,dut,client,host,off}
-			   Action:
-			   get - return selected mode
-			   dut - set to dut mode
-			   client - set to dut mode (alias for dut)
-			   host - set to host mode
-			   off - set to off mode
+     {get,dut,client,host,off,gpio,info}
+                           Supply one of the following commands to interact with the device
+       get                 Read the current state of the USB-SD-Mux
+       dut                 Switch to the DUT
+       client              Switch to the DUT
+       host                Switch to the host
+       off                 Disconnect from host and DUT
+       gpio                Manipulate a GPIO (open drain output only)
+       info                Show information about the SD card
 
-   optional arguments:
+   options:
      -h, --help            show this help message and exit
+     --json                Format output as json. Useful for scripting.
 
 Using as root
 -------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,43 @@
+import os
+
+import pytest
+
+import usbsdmux.__main__
+
+
+def test_usage(capsys, mocker):
+    "test that the usage output include the command name"
+    mocker.patch("sys.argv", ["usbsdmux"])
+    with pytest.raises(SystemExit):
+        usbsdmux.__main__.main()
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.startswith("usage: usbsdmux")
+
+
+def test_help_in_readme(capsys, mocker):
+    "test that the help output matches the readme"
+    mocker.patch("sys.argv", ["usbsdmux", "-h"])
+    with pytest.raises(SystemExit):
+        usbsdmux.__main__.main()
+    captured = capsys.readouterr()
+    assert captured.out.startswith("usage: usbsdmux")
+    assert captured.err == ""
+
+    readme_path = os.path.join(os.path.dirname(__file__), "../", "README.rst")
+    readme_lines = None
+    for line in open(readme_path).readlines():
+        line = line.rstrip()
+        if line == "   $ usbsdmux -h":
+            readme_lines = []
+        elif readme_lines is not None:
+            if line and not line.startswith("   "):
+                break
+            readme_lines.append(line)
+
+    assert readme_lines is not None
+    del readme_lines[-1]  # remove trailing empty line
+
+    output_lines = [f"   {line}".rstrip() for line in captured.out.splitlines()]
+
+    assert output_lines == readme_lines


### PR DESCRIPTION
The usbsdmux -h output in the README.rst has become out of date with the actual output of the tool.
This can be quite confusing, as it makes it unclear which features the tool has.

Update the README.rst content and make sure it stays up to date via a pytest test case.

This is an alternative to #64. Instead of adding a custom Actions workflow for a special check, integrate it as a test into the pytest testsuite. This also gives us the diff output through assertions (see https://github.com/jluebbe/usbsdmux/actions/runs/7288823489/job/19862144881#step:4:84 as an example).