### PR TITLE
README: Replace RAW-HTML with image

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,11 +31,10 @@ Under the hood this tool provides interfaces to access the following features of
 Packages
 --------
 
-.. raw:: html
-
-   <a href="https://repology.org/project/usbsdmux/versions">
-      <img src="https://repology.org/badge/vertical-allrepos/usbsdmux.svg?exclude_unsupported=1" alt="Packaging status" align="right">
-   </a>
+.. image:: https://repology.org/badge/vertical-allrepos/usbsdmux.svg
+   :target: https://repology.org/project/usbsdmux/versions
+   :alt: Packaging status
+   :align: right
 
 This tool is `packaged <https://packages.debian.org/search?keywords=usbsdmux&searchon=names&exact=1>`_ in Debian 12
 (aka *bookworm*) and later.


### PR DESCRIPTION
`.. raw::`-directives are not allowed on pypi. Let's just switch to using the image-directive to generate basically the same output.

I am aware that the `:align:` directive does not work in the rendered file (at the moment). This seems to be a consequence of how Github handles external images: For images that are part of the repository `:align:` works, but pointing to something outside the repository doesn't.