### PR TITLE
Testing: Allow to run tests locally and make README-test more verbose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,5 +44,5 @@ $(PYTHON_TESTING_ENV)/.created: REQUIREMENTS.qa.txt
 qa: $(PYTHON_TESTING_ENV)/.created
 	. $(PYTHON_TESTING_ENV)/bin/activate && \
 	black --check --diff . && \
-	flake8
-
+	flake8 && \
+	python3 -m pytest -vv

--- a/REQUIREMENTS.qa.txt
+++ b/REQUIREMENTS.qa.txt
@@ -2,4 +2,5 @@ black
 flake8
 flake8-pyproject
 flake8-bugbear
-
+pytest
+pytest-mock

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,7 @@ def test_usage(capsys, mocker):
         usbsdmux.__main__.main()
     captured = capsys.readouterr()
     assert captured.out == ""
-    assert captured.err.startswith("usage: usbsdmux")
+    assert captured.err.startswith("usage: usbsdmux"), "Invalid help: does not start with 'usage: usbsdmux'"
 
 
 def test_help_in_readme(capsys, mocker):
@@ -21,8 +21,8 @@ def test_help_in_readme(capsys, mocker):
     with pytest.raises(SystemExit):
         usbsdmux.__main__.main()
     captured = capsys.readouterr()
-    assert captured.out.startswith("usage: usbsdmux")
-    assert captured.err == ""
+    assert captured.out.startswith("usage: usbsdmux"), "Invalid help: does not start with 'usage: usbsdmux'"
+    assert captured.err == "", f"Execution of 'usbsdmux -h' failed: \n{captured.err}"
 
     readme_path = os.path.join(os.path.dirname(__file__), "../", "README.rst")
     readme_lines = None
@@ -35,9 +35,11 @@ def test_help_in_readme(capsys, mocker):
                 break
             readme_lines.append(line)
 
-    assert readme_lines is not None
+    assert readme_lines is not None, "Bash command not found. Did you include '   $ usbsdmux -h'?"
+    assert readme_lines, "No output lines found. Did you indent the output correctly?"
+
     del readme_lines[-1]  # remove trailing empty line
 
     output_lines = [f"   {line}".rstrip() for line in captured.out.splitlines()]
 
-    assert output_lines == readme_lines
+    assert output_lines == readme_lines, "Output of 'usbsdmux -h' does not match output in README.rst"


### PR DESCRIPTION
During development we wanted to run the tests locally. Since we only have a few tests we decided to add them to `make qa`.

This also adds a new check to `test_help_in_readme()` that fails when the output in the README is zero lines long. This can happen when indentation is wrong :-) 
(And while we are on it add some meaningful messages to the asserts.)

To be merged after #68 .