### PR TITLE
README: Update DCO to follow the kernel wording

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -203,4 +203,4 @@ Then you just add a line (using ``git commit -s``) saying:
 
   Signed-off-by: Random J Developer <random@developer.example.org>
 
-using your real name (sorry, no pseudonyms or anonymous contributions).
+using a known identity (sorry, no anonymous contributions).


### PR DESCRIPTION
Back in 2023 Linus updated the wording in the Kernel Documentation regarding the name in the s-o-b line.
He clarified that not only legal names, but also 'known identifies' are fine:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/Documentation/process/submitting-patches.rst?id=d4563201f33a022fc0353033d9dfeb1606a88330

This change aligns our DCO with the one in the kernel docs.