### PR TITLE
QA: Use ruff instead of black + flake8 for formatting and linting

### DIFF
--- a/.github/workflows/check-and-build.yaml
+++ b/.github/workflows/check-and-build.yaml
@@ -3,13 +3,6 @@ name: Check and Build
 on: [push, pull_request]
 
 jobs:
-  black:
-    name: Python black
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - run: make qa-black
-
   codespell:
     name: Codespell
     runs-on: ubuntu-latest
@@ -17,19 +10,19 @@ jobs:
       - uses: actions/checkout@v4
       - run: make qa-codespell
 
-  flake8:
-    name: Python flake8
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - run: make qa-flake8
-
   pytest:
-    name: Python pytest
+    name: Python Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - run: make qa-pytest
+
+  ruff:
+    name: Python Format and Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: make qa-ruff
 
   build:
     name: Python Build

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ clean:
 envs: packaging-env qa-env
 
 # testing #####################################################################
-.PHONY: qa qa-env qa-black qa-codespell qa-flake8 qa-pytest
+.PHONY: qa qa-env qa-codespell qa-pytest qa-ruff
 
 $(PYTHON_QA_ENV)/.created: REQUIREMENTS.qa.txt
 	rm -rf $(PYTHON_QA_ENV) && \
@@ -47,11 +47,7 @@ $(PYTHON_QA_ENV)/.created: REQUIREMENTS.qa.txt
 
 qa-env: $(PYTHON_QA_ENV)/.created
 
-qa: qa-black qa-codespell qa-flake8 qa-pytest
-
-qa-black: qa-env
-	. $(PYTHON_QA_ENV)/bin/activate && \
-	$(PYTHON) -m black --check --diff .
+qa: qa-codespell qa-pytest qa-ruff
 
 qa-codespell: qa-env
 	. $(PYTHON_QA_ENV)/bin/activate && \
@@ -61,10 +57,14 @@ qa-codespell-fix: qa-env
 	. $(PYTHON_QA_ENV)/bin/activate && \
 	codespell -w
 
-qa-flake8: qa-env
-	. $(PYTHON_QA_ENV)/bin/activate && \
-	$(PYTHON) -m flake8
-
 qa-pytest: qa-env
 	. $(PYTHON_QA_ENV)/bin/activate && \
 	$(PYTHON) -m pytest -vv
+
+qa-ruff: qa-env
+	. $(PYTHON_QA_ENV)/bin/activate && \
+	ruff format --check --diff && ruff check
+
+qa-ruff-fix: qa-env
+	. $(PYTHON_QA_ENV)/bin/activate && \
+	ruff format && ruff check --fix

--- a/REQUIREMENTS.qa.txt
+++ b/REQUIREMENTS.qa.txt
@@ -1,7 +1,4 @@
-black
 codespell
-flake8
-flake8-pyproject
-flake8-bugbear
 pytest
 pytest-mock
+ruff

--- a/fastentrypoints.py
+++ b/fastentrypoints.py
@@ -60,7 +60,7 @@ def get_args(cls, dist, header=None):
     """
     if header is None:
         header = cls.get_header()
-    spec = str(dist.as_requirement())
+    spec = str(dist.as_requirement())  # noqa: F841
     for type_ in "console", "gui":
         group = type_ + "_scripts"
         for name, ep in dist.get_entry_map(group).items():
@@ -94,14 +94,14 @@ def main():
         with open(manifest_path, "a+") as manifest:
             manifest.seek(0)
             manifest_content = manifest.read()
-            if not "include fastentrypoints.py" in manifest_content:
+            if "include fastentrypoints.py" not in manifest_content:
                 manifest.write(("\n" if manifest_content else "") + "include fastentrypoints.py")
 
         # Insert the import statement to setup.py if not present
         with open(setup_path, "a+") as setup:
             setup.seek(0)
             setup_content = setup.read()
-            if not "import fastentrypoints" in setup_content:
+            if "import fastentrypoints" not in setup_content:
                 setup.seek(0)
                 setup.truncate()
                 setup.write("import fastentrypoints\n" + setup_content)

--- a/fastentrypoints.py
+++ b/fastentrypoints.py
@@ -35,8 +35,9 @@ This is better.
 (c) 2016, Aaron Christianson
 http://github.com/ninjaaron/fast-entry_points
 """
-from setuptools.command import easy_install
 import re
+
+from setuptools.command import easy_install
 
 TEMPLATE = """\
 # -*- coding: utf-8 -*-

--- a/fastentrypoints.py
+++ b/fastentrypoints.py
@@ -35,6 +35,7 @@ This is better.
 (c) 2016, Aaron Christianson
 http://github.com/ninjaaron/fast-entry_points
 """
+
 import re
 
 from setuptools.command import easy_install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,16 @@
-[tool.black]
+[tool.ruff]
 line-length = 119
+exclude = [
+  "__pycache__",
+  "usbsdmux.egg-info",
+  ".pybuild",
+  "build",
+  "debian",
+  "env",
+  "venv",
+  "envs",
+  "dist",
+]
 
-[tool.flake8]
-max-line-length = 119
-count = true
-exclude = "build,debian,dist,envs,fastentrypoints.py,__pycache__,contrib,setup.py,venv,usbsdmux.egg-info,.tox"
+[tool.ruff.lint]
+select = ["B", "E", "F", "I", "SIM"]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-import fastentrypoints
+import fastentrypoints  # noqa: F401
 
 setup(
     name="usbsdmux",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from setuptools import setup
+
 import fastentrypoints
 
 setup(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -26,14 +26,16 @@ def test_help_in_readme(capsys, mocker):
 
     readme_path = os.path.join(os.path.dirname(__file__), "../", "README.rst")
     readme_lines = None
-    for line in open(readme_path).readlines():
-        line = line.rstrip()
-        if line == "   $ usbsdmux -h":
-            readme_lines = []
-        elif readme_lines is not None:
-            if line and not line.startswith("   "):
-                break
-            readme_lines.append(line)
+
+    with open(readme_path) as readme:
+        for line in readme.readlines():
+            line = line.rstrip()
+            if line == "   $ usbsdmux -h":
+                readme_lines = []
+            elif readme_lines is not None:
+                if line and not line.startswith("   "):
+                    break
+                readme_lines.append(line)
 
     assert readme_lines is not None, "Bash command not found. Did you include '   $ usbsdmux -h'?"
     assert readme_lines, "No output lines found. Did you indent the output correctly?"

--- a/tests/test_sd_regs.py
+++ b/tests/test_sd_regs.py
@@ -1,9 +1,9 @@
-import os.path
 import json
+import os.path
 
 import pytest
 
-from usbsdmux.sd_regs import SCR, CID, decode_csd
+from usbsdmux.sd_regs import CID, SCR, decode_csd
 
 REFS = [
     "02544d53413034471027b7748500bc00",

--- a/tests/test_sd_regs.py
+++ b/tests/test_sd_regs.py
@@ -16,7 +16,9 @@ REFS = [
 @pytest.mark.parametrize("cid", REFS)
 def test_decode(cid):
     ref_name = os.path.join(os.path.dirname(__file__), "reference", f"{cid}.json")
-    ref = json.load(open(ref_name))
+
+    with open(ref_name) as ref_file:
+        ref = json.load(ref_file)
 
     res = {}
     res["scr"] = SCR(ref["scr"]["raw"]).decode()
@@ -33,8 +35,12 @@ def test_decode(cid):
 def test_to_text(cid):
     ref_name_json = os.path.join(os.path.dirname(__file__), "reference", f"{cid}.json")
     ref_name_text = os.path.join(os.path.dirname(__file__), "reference", f"{cid}.text")
-    ref_json = json.load(open(ref_name_json))
-    ref_text = open(ref_name_text).read().split("\n")[:-1]
+
+    with open(ref_name_json) as ref_file_json:
+        ref_json = json.load(ref_file_json)
+
+    with open(ref_name_text) as ref_file_text:
+        ref_text = ref_file_text.read().split("\n")[:-1]
 
     res = []
 

--- a/usbsdmux/__main__.py
+++ b/usbsdmux/__main__.py
@@ -20,12 +20,12 @@
 
 import argparse
 import errno
-import sys
 import json
+import sys
 
-from .usbsdmux import autoselect_driver, UnknownUsbSdMuxRevisionException, NotInHostModeException
-from .sd_regs import decoded_to_text
 from .mqtthelper import Config, publish_info
+from .sd_regs import decoded_to_text
+from .usbsdmux import NotInHostModeException, UnknownUsbSdMuxRevisionException, autoselect_driver
 
 
 def main():

--- a/usbsdmux/ctypehelper.py
+++ b/usbsdmux/ctypehelper.py
@@ -50,10 +50,8 @@ def string_to_uint8_array(str, array_length, c_string=False, padding=0xFF, encod
 
     # Determine number of bytes to copy
     nbytes = str.encode(encoding)
-    if c_string:
-        count = min(len(nbytes), array_length - 1)
-    else:
-        count = min(len(nbytes), array_length)
+    length = array_length - 1 if c_string else array_length
+    count = min(len(nbytes), length)
 
     # Do the actual copy
     for i in range(count):

--- a/usbsdmux/i2c_gpio.py
+++ b/usbsdmux/i2c_gpio.py
@@ -18,8 +18,9 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-from .usb2642 import Usb2642
 from abc import ABC
+
+from .usb2642 import Usb2642
 
 
 class I2cGpio(ABC):

--- a/usbsdmux/i2c_gpio.py
+++ b/usbsdmux/i2c_gpio.py
@@ -18,12 +18,10 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-from abc import ABC
-
 from .usb2642 import Usb2642
 
 
-class I2cGpio(ABC):
+class I2cGpio(object):
     # Registers inside the supported GPIO expanders
     _register_inputPort = 0x00
     _register_outputPort = 0x01

--- a/usbsdmux/mqtthelper.py
+++ b/usbsdmux/mqtthelper.py
@@ -1,7 +1,7 @@
-import os
-import sys
 import configparser
 import json
+import os
+import sys
 
 
 class Config:
@@ -63,6 +63,7 @@ def _read_int(filename, base=10):
 
 def _gather_data(ctl, sg, mode):
     import socket
+
     import pkg_resources
 
     base_sg = os.path.realpath(sg)

--- a/usbsdmux/sd_regs.py
+++ b/usbsdmux/sd_regs.py
@@ -137,10 +137,7 @@ class CSD_Common(RegisterDecoder):
         scale = TIME_SCALE_ENUM[bitslice(v[0], 2, 0)]
         value = self.TIME_VALUE_ENUM[bitslice(v[0], 6, 3)]
 
-        if isinstance(value, float):
-            scaled_value = value * scale
-        else:
-            scaled_value = None
+        scaled_value = value * scale if isinstance(value, float) else None
 
         return {
             "decoded": (value, unit),
@@ -156,10 +153,10 @@ class CSD_Common(RegisterDecoder):
         scale = RATE_SCALE_ENUM[bitslice(v[0], 2, 0)]
         value = self.TIME_VALUE_ENUM[bitslice(v[0], 6, 3)]
 
+        scaled_value = None
+
         if isinstance(value, float) and isinstance(scale, int):
             scaled_value = value * scale
-        else:
-            scaled_value = None
 
         return {
             "decoded": (value, unit),
@@ -517,7 +514,8 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    data = json.loads(open(args.input).read())
+    with open(args.input) as fd:
+        data = json.loads(fd.read())
 
     if args.json:
         res = {}

--- a/usbsdmux/sd_regs.py
+++ b/usbsdmux/sd_regs.py
@@ -50,6 +50,7 @@ def decoded_to_text(decoded):
 
 class RegisterDecoder:
     "decode a register based on a mostly declarative description of the contents."
+
     FIELDS = {}
 
     def __init__(self, raw_hex):

--- a/usbsdmux/usb2642eeprom.py
+++ b/usbsdmux/usb2642eeprom.py
@@ -23,9 +23,9 @@ import ctypes
 import time
 
 from .ctypehelper import (
+    list_to_uint8_array,
     string_to_microchip_unicode_uint8_array,
     string_to_uint8_array,
-    list_to_uint8_array,
 )
 from .usb2642 import Usb2642
 

--- a/usbsdmux/usbsdmux.py
+++ b/usbsdmux/usbsdmux.py
@@ -21,8 +21,8 @@
 import os
 import time
 
-from .i2c_gpio import Pca9536, Tca6408
 from . import sd_regs
+from .i2c_gpio import Pca9536, Tca6408
 
 
 class UnknownUsbSdMuxRevisionException(Exception):


### PR DESCRIPTION
The main benefit of using `ruff` for us is that its rules are automatically consistent between the formatter and linter, while `black` and `flake8` are often caught fighting about the correct formatting and need fine tuned configurations to prevent that.

This aligns with changes we have previously made to  [usbmuxctl](https://github.com/linux-automation/usbmuxctl) and [lxa-iobus](https://github.com/linux-automation/lxa-iobus).

TODO before merging:

- [x] This PR is based on #74, which lays down some groundwork on the CI jobs.