### PR TITLE
usbsdmux: add ruff "UP" rules to config and fix issues automatically

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,4 +54,4 @@ exclude = [
 ]
 
 [tool.ruff.lint]
-select = ["B", "E", "F", "I", "SIM"]
+select = ["B", "E", "F", "I", "SIM", "UP"]

--- a/usbsdmux/ctypehelper.py
+++ b/usbsdmux/ctypehelper.py
@@ -124,7 +124,7 @@ def to_pretty_hex(buffer):
         temp_buf = temp_buf[8:]
         res += "0x{:02X}\t{}  {}\n".format(
             offs,
-            " ".join(["{:02X}".format(x) for x in window]),
+            " ".join([f"{x:02X}" for x in window]),
             " ".join([chr(x) if chr(x) in string.printable.split(" ")[0] else "." for x in window]),
         )
         offs += 8

--- a/usbsdmux/i2c_gpio.py
+++ b/usbsdmux/i2c_gpio.py
@@ -21,7 +21,7 @@
 from .usb2642 import Usb2642
 
 
-class I2cGpio(object):
+class I2cGpio:
     # Registers inside the supported GPIO expanders
     _register_inputPort = 0x00
     _register_outputPort = 0x01

--- a/usbsdmux/mqtthelper.py
+++ b/usbsdmux/mqtthelper.py
@@ -48,7 +48,7 @@ class Config:
 
 def _read_file(filename):
     try:
-        with open(filename, "r") as f:
+        with open(filename) as f:
             return f.read()
     except FileNotFoundError:
         return None

--- a/usbsdmux/usb2642.py
+++ b/usbsdmux/usb2642.py
@@ -48,7 +48,7 @@ class SDTransactionFailed(Exception):
     pass
 
 
-class Usb2642(object):
+class Usb2642:
     """
     This class provides an interface to interact with devices on a Microchip
     USB2642 auxiliary I2C Bus and to write configuration to an EEPROM on the
@@ -342,7 +342,7 @@ class Usb2642(object):
         with open(self.sg, "r+b", buffering=0) as fh:
             rc = fcntl.ioctl(fh, self._SG_IO, sgio)
             if rc != 0:
-                raise IoctlFailed("SG_IO ioctl() failed with non-zero exit-code {}".format(rc))
+                raise IoctlFailed(f"SG_IO ioctl() failed with non-zero exit-code {rc}")
         return databuffer, sense, sgio
 
     def write_config(self, data):
@@ -417,7 +417,7 @@ class Usb2642(object):
 
         if sgio.status != 0:
             raise I2cTransactionFailed(
-                "SCSI-Transaction ended with status {}. I2C-Transaction has probably failed.".format(sgio.status)
+                f"SCSI-Transaction ended with status {sgio.status}. I2C-Transaction has probably failed."
             )
 
         return list(data[:readLength])
@@ -453,7 +453,7 @@ class Usb2642(object):
 
         if sgio.status != 0:
             raise I2cTransactionFailed(
-                "SCSI-Transaction ended with status {}. I2C-Transaction has probably failed.".format(sgio.status)
+                f"SCSI-Transaction ended with status {sgio.status}. I2C-Transaction has probably failed."
             )
 
     def _read_register(self, reg, size, retries=5):
@@ -472,7 +472,7 @@ class Usb2642(object):
 
             if sgio.status != 0:
                 raise SDTransactionFailed(
-                    "SCSI Transaction ended with status {}. SD Transaction has probably failed.".format(sgio.status)
+                    f"SCSI Transaction ended with status {sgio.status}. SD Transaction has probably failed."
                 )
 
             break

--- a/usbsdmux/usb2642eeprom.py
+++ b/usbsdmux/usb2642eeprom.py
@@ -39,7 +39,7 @@ class VerificationFailedException(Exception):
     pass
 
 
-class USB2642Eeprom(object):
+class USB2642Eeprom:
     """
     Provides an interface to write the configuration EEPROM of a USB2642.
     """

--- a/usbsdmux/usbsdmux.py
+++ b/usbsdmux/usbsdmux.py
@@ -45,7 +45,7 @@ def autoselect_driver(sg):
     sg_name = os.path.basename(base_sg)
     model_filename = f"/sys/class/scsi_generic/{sg_name}/device/model"
     try:
-        with open(model_filename, "r") as fh:
+        with open(model_filename) as fh:
             model = fh.read().strip()
         if model == "sdmux HS-SD/MMC":
             return UsbSdMuxClassic(sg)


### PR DESCRIPTION
This commit is the result of adding the ["UP"](https://docs.astral.sh/ruff/rules/#pyupgrade-up) set of rules to the ruff linter config and running `make qa-ruff-fix` (a.k.a. `ruff check --fix`).

This change was inspired by a comment from @jluebbe about the (superfluous) use of `class …(object):` in bb17e2eb706b717c644810a44aeabffa8cdb8730 (merged in #75).