### PR TITLE
pyproject.toml: fix fallout from the migration

### DIFF
--- a/REQUIREMENTS.qa.txt
+++ b/REQUIREMENTS.qa.txt
@@ -1,4 +1,0 @@
-codespell
-pytest
-pytest-mock
-ruff

--- a/usbsdmux/mqtthelper.py
+++ b/usbsdmux/mqtthelper.py
@@ -132,7 +132,7 @@ def _gather_data(ctl, sg, mode):
 def publish_info(ctl, config, sg, mode):
     """
     Publish info to mqtt server, if mqtt is enabled.
-    This requires installing REQUIREMENTS.mqtt.txt.
+    This requires installing paho-mqtt.
     """
 
     if not config.mqtt_enabled:
@@ -146,7 +146,9 @@ def publish_info(ctl, config, sg, mode):
     except ImportError:
         print(
             "Sending data to an mqtt server requires paho-mqtt",
-            "Please install REQUIREMENTS.mqtt.txt",
+            "Please install it, e.g. by installing usbsdmux via:",
+            "",
+            '    python3 -m pip install "usbsdmux[mqtt]"',
             sep="\n",
             file=sys.stderr,
         )


### PR DESCRIPTION
It turns out that some points were missed when doing the `pyproject.toml` migration in #76.

Nothing mayor so far, but a few inconsistencies nevertheless.

This PR fixes two of them. Time will tell if there are even more.