### PR TITLE
usb-sd-mux/FAST: Fix GPIO number-to-pin definition

### DIFF
--- a/usbsdmux/usbsdmux.py
+++ b/usbsdmux/usbsdmux.py
@@ -217,8 +217,8 @@ class UsbSdMuxFast(UsbSdMux):
     _card_inserted = 0x00
     _card_removed = Tca6408.gpio_3
 
-    gpio0 = Tca6408.gpio_4
-    gpio1 = Tca6408.gpio_5
+    gpio0 = Tca6408.gpio_5
+    gpio1 = Tca6408.gpio_4
 
     def __init__(self, sg):
         self._tca = Tca6408(sg)


### PR DESCRIPTION
This change fixes the mapping between the GPIO numbers (as written on the device) and the IOs of the I2C port-expander.

This mismatch was present since support for the FAST was added in ab421354c2bfeecd634a8ec54fb27e6a24c8c82a.
It seems the swapping of the pins in the schematic has been overlooked (see https://github.com/linux-automation/usbsdmux/issues/83 for that particular part of the schematic) during tool development. Additionally early prototypes were missing the GPIO numbers in silkscreen - masking this problem.

With this change we will break the pin assignment for all users of releases up to 24.01.1. Thus this must be added to the release notes.

I have tested these changes on a series production device. The pin definition is now correct.