### PR TITLE
contrib/udev: explicitly load the sg module in the udev rule

### DIFF
--- a/contrib/udev/99-usbsdmux.rules
+++ b/contrib/udev/99-usbsdmux.rules
@@ -1,3 +1,5 @@
 # USB-SD-Mux
 ACTION=="add", SUBSYSTEM=="scsi_generic", KERNEL=="sg[0-9]*", ATTRS{manufacturer}=="Pengutronix", ATTRS{product}=="usb-sd-mux*", SYMLINK="usb-sd-mux/id-$attr{serial}", TAG+="uaccess", GROUP="plugdev"
 ACTION=="add", SUBSYSTEM=="scsi_generic", KERNEL=="sg[0-9]*", ATTRS{manufacturer}=="Linux Automation GmbH", ATTRS{product}=="usb-sd-mux*", SYMLINK="usb-sd-mux/id-$attr{serial}", TAG+="uaccess", GROUP="plugdev"
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{manufacturer}=="Pengutronix", ATTRS{product}=="usb-sd-mux*", RUN{builtin}+="kmod load sg"
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{manufacturer}=="Linux Automation GmbH", ATTRS{product}=="usb-sd-mux*", RUN{builtin}+="kmod load sg"


### PR DESCRIPTION
We never got around to figuring out why the `sg` module is auto-loaded on some systems/distributions (e.g. Debian) but not on others (e.g. Arch). We have since used workarounds like adding `sg` to `/etc/modules`.

Instead just use udev to load the module if a new USB-SD-Mux is connected, as suggested by @frosteyes in https://github.com/linux-automation/usbsdmux/issues/87.

I've tested the change on may Arch Linux System that would not automatically load the `sg` module before, but does with the updated udev rule. I've also checked if having an explicit `kmod load` in an (upstream) udev rule is uncommon:

```
$ cd /usr/lib/udev
rg kmod
rules.d/80-drivers.rules
5:ENV{MODALIAS}=="?*", RUN{builtin}+="kmod load"
6:SUBSYSTEM=="tifm", ENV{TIFM_CARD_TYPE}=="SD", RUN{builtin}+="kmod load tifm_sd"
7:SUBSYSTEM=="tifm", ENV{TIFM_CARD_TYPE}=="MS", RUN{builtin}+="kmod load tifm_ms"
8:SUBSYSTEM=="memstick", RUN{builtin}+="kmod load ms_block mspro_block"
9:SUBSYSTEM=="i2o", RUN{builtin}+="kmod load i2o_block"
10:SUBSYSTEM=="module", KERNEL=="parport_pc", RUN{builtin}+="kmod load ppdev"
11:KERNEL=="mtd*ro", ENV{MTD_FTL}=="smartmedia", RUN{builtin}+="kmod load sm_ftl"
```

This looks to me like they are not _that_ common, but they exist.

Resolves #87.