### PR TITLE
usbsdmux: sd_regs: Fix ruff error regarding the use of percent formatting

### DIFF
--- a/usbsdmux/sd_regs.py
+++ b/usbsdmux/sd_regs.py
@@ -35,8 +35,13 @@ def decoded_to_text(decoded):
             text.append(f"  {f['field']}: {f['name']}")
         else:
             text.append(f"  {f['field']}")
-        raw = f["raw"]
-        text.append(f"    raw: 0b{format(raw[0], '0%db' % raw[1])} == 0x{raw[0]:0x} == {int(raw[0])}")
+
+        (raw_value, raw_width) = f["raw"]
+
+        # Pad the binary representation of `raw_value` to the number of bits of the field.
+        bits_str = format(raw_value, f"0{raw_width}b")
+        text.append(f"    raw: 0b{bits_str} == 0x{raw_value:0x} == {int(raw_value)}")
+
         if "enum" in f:
             text.append(f"    enum: {f['enum']} {f.get('unit', '')}".rstrip())
         if "bits" in f:


### PR DESCRIPTION
It looks like `ruff` has learned a new trick, making the CI pipeline in #88 fail, even though it did not touch the python code at all.
This PR should fix that.

The primary goal of this commit is fixing the following `ruff` linting error:

    usbsdmux/sd_regs.py:39:50: UP031 Use format specifiers instead of percent format
       |
    37 |             text.append(f"  {f['field']}")
    38 |         raw = f["raw"]
    39 |         text.append(f"    raw: 0b{format(raw[0], '0%db' % raw[1])} == 0x{raw[0]:0x} == {int(raw[0])}")
       |                                                  ^^^^^^ UP031
    40 |         if "enum" in f:
    41 |             text.append(f"    enum: {f['enum']} {f.get('unit', '')}".rstrip())
       |
       = help: Replace with format specifiers

While at it I had a hard time understanding what the offending code does, so I have decided to restructure it a bit while at it.

The code path is covered by the pytest testsuite, so we can be somewhat certain that the behaviour did not change.