### PR TITLE
CI: run checks on a schedule and allow workflow_dispatch

### DIFF
--- a/.github/workflows/check-and-publish.yaml
+++ b/.github/workflows/check-and-publish.yaml
@@ -1,6 +1,11 @@
 name: Check and Publish
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: '22 15 * * 3'
+  workflow_dispatch:
 
 jobs:
   codespell:


### PR DESCRIPTION
Running checks on a schedule makes sense for our `ruff` lints and our `codespell` spell checks, because these tools learn new lints/typo fixes every then and now.
Without periodic job runs these new lints/typo fixes will only surface when jobs for the next pull request fail for unrelated reasons.

The execution time of the scheduled job is chosen somewhat arbitrarily.

While at it also enable workflow_dispatch as a trigger, which can be used to run the jobs manually.