### PR TITLE
CI: update reuse-action to v5

### DIFF
--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -10,4 +10,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: REUSE Compliance Check
-        uses: fsfe/reuse-action@v4
+        uses: fsfe/reuse-action@v5


### PR DESCRIPTION
This updates the check to use version 3.3 of the spec.