### PR TITLE
README: suggest `udevadm test /dev/sgX` for debugging udev issues

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -188,6 +188,9 @@ the ``/dev/usb-sd-mux/`` directory:
     lrwxrwxrwx 1 root plugdev 6 Mar 27 00:33 id-000000000078 -> ../sg2
     lrwxrwxrwx 1 root plugdev 6 Mar 24 09:51 id-000000000378 -> ../sg1
 
+If it does not work as expected the udevadm test command can be used
+to get more information and debug: ``udevadm test /dev/sg2``.
+
 .. [1] The ``plugdev`` group is used in Debian and Debian based distributions
        (like Ubuntu and Linux Mint) to grant access to pluggable gadgets.
        Depending on your Linux distribution you may want to create/use another


### PR DESCRIPTION
I created the plugdev group, and expected the default rule to work. I was not sure how to debug it, but learnt about the very useful udevadm test command, with which it was clear as day that simply creating a plugdev group would not work on my system:

```
$ udevadm test /dev/sg2
[ ... ]
Reading rules file: /etc/udev/rules.d/99-usbsdmux.rules
varlink: Setting state idle-client
/run/systemd/userdb/io.systemd.Multiplexer: Sending message: {"method":"io.systemd.UserDatabase.GetGroupRecord","parameters":{"groupName":"plugdev","gidMax":65533,"service":"io.systemd.Multiplexer"}}
/run/systemd/userdb/io.systemd.Multiplexer: Changing state idle-client → awaiting-reply
/run/systemd/userdb/io.systemd.Multiplexer: Received message: {"parameters":{"record":{"groupName":"plugdev","gid":1002,"members":["foobar"],"privileged":{"hashedPassword":["!"]},"status":{"7abeef6a2a394008bb35f4ea21607bca":{"service":"io.systemd.NameServiceSwitch"}}},"incomplete":true}}
/run/systemd/userdb/io.systemd.Multiplexer: Changing state awaiting-reply → processing-reply
/run/systemd/userdb/io.systemd.Multiplexer: Changing state processing-reply → idle-client
/etc/udev/rules.d/99-usbsdmux.rules:6 Failed to resolve group 'plugdev', ignoring: Not a system group
[ ... ]
```

I had to change so that it uses group "disk" instead. Add hint about the udevadm test command to the README to help others facing similar issues.