### PR TITLE
usbsdmux: sd_regs: re-format using ruff 0.15.0

### DIFF
--- a/usbsdmux/sd_regs.py
+++ b/usbsdmux/sd_regs.py
@@ -304,7 +304,7 @@ class CSD_10(CSD_Common):
     FIELDS["C_SIZE"] = {
         "slice": (73, 62),
         "name": "device size",
-        "convert": lambda v: (v + 1),
+        "convert": lambda v: v + 1,
     }
     FIELDS["VDD_R_CURR_MIN"] = {
         "slice": (61, 59),


### PR DESCRIPTION
Ruff now seems to remove unnecessary parentheses in lambdas.

This should fix the scheduled CI job, [which has failed yesterday](https://github.com/linux-automation/usbsdmux/actions/runs/21678696307/job/62506431556) due to the ruff formatting job.