### PR TITLE
MQTT: fix spelling mistake

### DIFF
--- a/usbsdmux/mqtthelper.py
+++ b/usbsdmux/mqtthelper.py
@@ -150,7 +150,7 @@ def publish_info(ctl: UsbSdMux, config: Config, sg: str, mode: str) -> None:
         import paho.mqtt.publish as mqtt
     except ImportError:
         print(
-            "Sending data to a mqtt server requires paho-mqtt",
+            "Sending data to an mqtt server requires paho-mqtt",
             "Please install it, e.g. by installing usbsdmux via:",
             "",
             '    python3 -m pip install "usbsdmux[mqtt]"',


### PR DESCRIPTION
Since "Em Cue Tee Tee" starts with a vowel ("em"), the indefinite article needs to be an "an" in this instance.

See also: <https://www.merriam-webster.com/grammar/is-it-a-or-an>

Fixes: 0f51f58e0245 ("MQTT: Print Error, but Continue if Sending Fails")