### PR TITLE
tests: cli: Fix for interpreter versions >= v3.14.0

### DIFF
--- a/usbsdmux/__main__.py
+++ b/usbsdmux/__main__.py
@@ -14,7 +14,7 @@ from .usbsdmux import NotInHostModeException, UnknownUsbSdMuxRevisionException, 
 
 
 def main():
-    parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
+    parser = argparse.ArgumentParser(prog=sys.argv[0], formatter_class=argparse.RawTextHelpFormatter)
 
     parser.add_argument("sg", metavar="SG", help="/dev/sg* to use")
 


### PR DESCRIPTION
Both tests in test_cli.py fail when they are run with Python interpreter versions greater then v3.14.0.

It is the first release with [1] included, changing the way in which the default value is chosen for the prog argument if it is not provided. "python3" is now returned instead of usbsdmux breaking the tests expectations.

Explicitly set prog to sys.argv[0] to keep the original behaviour.

[1] 04bfea2d261b ("gh-66436: Improved prog default value for argparse.ArgumentParser (GH-124799)")

Its not really a quality fix, but hopefully also not to offending.